### PR TITLE
Fixed an issue where void was ending up in the schema definition

### DIFF
--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckle/Providers/FunctionApiDescriptionProvider.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckle/Providers/FunctionApiDescriptionProvider.cs
@@ -247,19 +247,24 @@ namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Providers
         {
             return methodInfo.GetCustomAttributes(typeof(ProducesResponseTypeAttribute))
                 .Select(customAttribute => customAttribute as ProducesResponseTypeAttribute)
-                .Select(responseType => new ApiResponseType
+                .Select(responseType =>
                 {
-                    ApiResponseFormats = new[]
+                    var isVoidResponseType = responseType.Type == typeof(void);
+                    
+                    return new ApiResponseType
                     {
-                        new ApiResponseFormat
+                        ApiResponseFormats = new[]
                         {
-                            Formatter = _outputFormatter,
-                            MediaType = "application/json"
-                        }
-                    },
-                    ModelMetadata = _modelMetadataProvider.GetMetadataForType(responseType.Type),
-                    Type = responseType.Type,
-                    StatusCode = responseType.StatusCode
+                            new ApiResponseFormat
+                            {
+                                Formatter = _outputFormatter,
+                                MediaType = "application/json"
+                            }
+                        },
+                        ModelMetadata = isVoidResponseType ? null : _modelMetadataProvider.GetMetadataForType(responseType.Type),
+                        Type = isVoidResponseType ? null : responseType.Type,
+                        StatusCode = responseType.StatusCode
+                    };
                 });
         }
 


### PR DESCRIPTION
Some APIs do not have a response type, Like a 404 response.
Currently this causes the void "object" ending up in the schema definition.

To reproduce just add ``[(int) HttpStatusCode.NotFound)]`` to one of the function endpoints.

This change will filter out void from the schema definition