### PR TITLE
Consolidated extensions and added one to support .net 5

### DIFF
--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckleStartupExtension.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckleStartupExtension.cs
@@ -21,23 +21,7 @@ namespace AzureFunctions.Extensions.Swashbuckle
             Assembly assembly,
             Action<SwaggerDocOptions> configureDocOptionsAction = null)
         {
-            builder.AddExtension<SwashbuckleConfig>()
-                .BindOptions<SwaggerDocOptions>()
-                .ConfigureOptions<SwaggerDocOptions>((configuration, section, options) =>
-                {
-                    configureDocOptionsAction?.Invoke(options);
-                });
-
-            builder.Services.AddSingleton<IModelMetadataProvider>(new EmptyModelMetadataProvider());
-            builder.Services.AddSingleton(new SwashBuckleStartupConfig
-            {
-                Assembly = assembly
-            });
-
-            var formatter = new SystemTextJsonOutputFormatter(new JsonSerializerOptions());
-            builder.Services.AddSingleton<IOutputFormatter>(formatter);
-            builder.Services.AddSingleton<IApiDescriptionGroupCollectionProvider, FunctionApiDescriptionProvider>();
-
+            builder.Services.AddSwashBuckle(assembly, configureDocOptionsAction, builder);
             return builder;
         }
 
@@ -46,23 +30,33 @@ namespace AzureFunctions.Extensions.Swashbuckle
             Assembly assembly,
             Action<SwaggerDocOptions> configureDocOptionsAction = null)
         {
-            var wbBuilder = builder.Services.AddWebJobs(_ => { });
+            builder.Services.AddSwashBuckle(assembly, configureDocOptionsAction);
+            return builder;
+        }
 
-            wbBuilder.AddExtension<SwashbuckleConfig>()
+        public static IServiceCollection AddSwashBuckle(
+            this IServiceCollection services,
+            Assembly assembly,
+            Action<SwaggerDocOptions> configureDocOptionsAction = null, 
+            IWebJobsBuilder webJobsBuilder = null)
+        {
+            webJobsBuilder ??= services.AddWebJobs(_ => { });
+
+            webJobsBuilder.AddExtension<SwashbuckleConfig>()
                 .BindOptions<SwaggerDocOptions>()
                 .ConfigureOptions<SwaggerDocOptions>((configuration, section, options) => configureDocOptionsAction?.Invoke(options));
 
-            builder.Services.AddSingleton<IModelMetadataProvider>(new EmptyModelMetadataProvider());
-            builder.Services.AddSingleton(new SwashBuckleStartupConfig
+            services.AddSingleton<IModelMetadataProvider>(new EmptyModelMetadataProvider());
+            services.AddSingleton(new SwashBuckleStartupConfig
             {
                 Assembly = assembly
             });
 
             var formatter = new SystemTextJsonOutputFormatter(new JsonSerializerOptions());
-            builder.Services.AddSingleton<IOutputFormatter>(formatter);
-            builder.Services.AddSingleton<IApiDescriptionGroupCollectionProvider, FunctionApiDescriptionProvider>();
+            services.AddSingleton<IOutputFormatter>(formatter);
+            services.AddSingleton<IApiDescriptionGroupCollectionProvider, FunctionApiDescriptionProvider>();
 
-            return builder;
+            return services;
         }
     }
 }


### PR DESCRIPTION
Consolidated extensions with a new IServiceCollection extension that is also public to enabling support for .net 5 implementation that is no longer using IFunctionsHostBuilder.

See details for .net 5 implementation here:
https://github.com/Azure/azure-functions-dotnet-worker-preview

Alternatively I could bypass these extensions and modify the configurations myself, but a few of required classes are internal:

SwashbuckleConfig
SwaggerDocOptions
SwashBuckleStartupConfig
FunctionApiDescriptionProvider
