### PR TITLE
querystring parameter example update

### DIFF
--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/Attribute/QueryStringParamaterAttribute.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/Attribute/QueryStringParamaterAttribute.cs
@@ -1,19 +1,89 @@
-﻿using System;
+using Microsoft.OpenApi.Any;
+using System;
 
 namespace AzureFunctions.Extensions.Swashbuckle.Attribute
+
 {
+
     [AttributeUsage(AttributeTargets.Method, Inherited = false, AllowMultiple = true)]
     public class QueryStringParameterAttribute : System.Attribute
-    {
+
+    { 
         public QueryStringParameterAttribute(string name, string description)
+
+        {
+
+            Initialise(name, description);
+            Example = new OpenApiNull();
+        }
+
+        public QueryStringParameterAttribute(string name, string description, string example)
+        {
+
+            Initialise(name, description);
+            DataType = typeof(string);
+            Example = new OpenApiString(example);
+        }
+
+        public QueryStringParameterAttribute(string name, string description, int example)
+        {
+            Initialise(name, description);
+            DataType = typeof(int);
+            Example = new OpenApiInteger(example);
+        }
+
+        public QueryStringParameterAttribute(string name, string description, long example)
+        {
+
+            Initialise(name, description);
+            DataType = typeof(long);
+            Example = new OpenApiLong(example);
+        }
+
+        public QueryStringParameterAttribute(string name, string description, double example)
+        {
+            Initialise(name, description);
+            Example = new OpenApiDouble(example);
+        }
+
+        public QueryStringParameterAttribute(string name, string description, float example)
+        { 
+            Initialise(name, description);
+            DataType = typeof(float);
+            Example = new OpenApiFloat(example);
+        }
+
+        public QueryStringParameterAttribute(string name, string description, byte example)
+        {
+            Initialise(name, description);
+            DataType = typeof(byte);
+            Example = new OpenApiByte(example);
+        }
+
+        public QueryStringParameterAttribute(string name, string description, bool example)
+        {
+            Initialise(name, description);
+            DataType = typeof(bool);
+            Example = new OpenApiBoolean(example);
+        }
+
+        private void Initialise(string name, string description)
         {
             Name = name;
             Description = description;
         }
 
-        public string Name { get; }
+        #region public properties
+
+        public string Name { get; set; }
         public Type DataType { get; set; }
-        public string Description { get; }
+        public string Description { get; set; }
         public bool Required { get; set; } = false;
+        public IOpenApiAny Example { get; }
+
+        #endregion
+
     }
+
 }
+

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckle/Filters/QueryStringParameterAttributeFilter.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckle/Filters/QueryStringParameterAttributeFilter.cs
@@ -1,5 +1,6 @@
-﻿using System.Linq;
+using System.Linq;
 using AzureFunctions.Extensions.Swashbuckle.Attribute;
+using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
@@ -24,16 +25,33 @@ namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters
 
                 foreach (var attribute in attributes)
                 {
-                    var attributeTypeName = new OpenApiSchema {Type = "string"};
-
-                    operation.Parameters.Add(new OpenApiParameter
+                    // var attributeTypeName = new OpenApiSchema {Type = "string"};
+                    var apiParameter = new OpenApiParameter
                     {
                         Name = attribute.Name,
                         Description = attribute.Description,
                         In = ParameterLocation.Query,
                         Required = attribute.Required,
                         Schema = schemaGenerator.GenerateSchema(attribute?.DataType, new SchemaRepository())
-                    });
+                    };
+
+
+                    switch (attribute.Example)
+                    {
+
+                        case OpenApiNull _:
+                            /* ignore */
+                            break;
+
+                        default:
+                            // set both examples
+                            apiParameter.Schema.Example = attribute.Example;
+                            apiParameter.Example = apiParameter.Schema.Example;
+                            break;
+                    }
+
+                    operation.Parameters.Add(apiParameter);
+
                 }
             }
         }

--- a/src/AzureFunctions.Extensions.Swashbuckle/TestFunction/TestController.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/TestFunction/TestController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -18,6 +18,19 @@ namespace TestFunction
     [ApiExplorerSettings(GroupName = "testee")]
     public class TestController
     {
+
+        [ProducesResponseType(typeof(TestModel[]), (int)HttpStatusCode.OK)]
+        [FunctionName("TestGetWithExamples")]
+        [QueryStringParameter("colour", "The colour of the bike", "Red", Required = true)]
+        [QueryStringParameter("wheelsize", "Size of wheel", 26, Required = true)]
+        [QueryStringParameter("used", "Must be used", false, Required = false)]
+        public async Task<IActionResult> GetExamples([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getexampletest")]
+            HttpRequest request)
+        {
+            return new OkObjectResult(new[] { new TestModel(), new TestModel() });
+        }
+
+
         [ProducesResponseType(typeof(TestModel[]), (int)HttpStatusCode.OK)]
         [FunctionName("TestGets")]
         [QueryStringParameter("expand", "it is expand parameter", DataType = typeof(int), Required = true)]


### PR DESCRIPTION
Querystring parameter example support for primitive types on GET requests.
 
[QueryStringParameter("colour", "The colour of the bike", "Red", Required = true)]
[QueryStringParameter("wheelsize", "Size of wheel", 26, Required = true)]
[QueryStringParameter("used", "Must be used", false, Required = false)]



