### PR TITLE
Adjusted usage of attribute properties in filter

### DIFF
--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckle/Filters/FileUploadOperationFilter.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckle/Filters/FileUploadOperationFilter.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using AzureFunctions.Extensions.Swashbuckle.Attribute;
 using Microsoft.OpenApi.Any;
@@ -37,6 +36,14 @@ namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters
 
                 operation.RequestBody.Content[MimeType].Schema ??= new OpenApiSchema();
 
+                var uploadFileName = string.IsNullOrEmpty(uploadFile.Name)
+                    ? "uploadedFile"
+                    : uploadFile.Name;
+
+                var uploadFileDescription = string.IsNullOrEmpty(uploadFile.Name)
+                    ? "File to upload."
+                    : uploadFile.Description;
+
                 var uploadFileMediaType = new OpenApiMediaType
                 {
                     Schema = new OpenApiSchema
@@ -44,16 +51,16 @@ namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters
                         Type = "object",
                         Properties =
                         {
-                            ["uploadedFile"] = new OpenApiSchema
+                            [uploadFileName] = new OpenApiSchema
                             {
-                                Description = "File to upload.",
+                                Description = uploadFileDescription,
                                 Type = "file",
                                 Format = "binary"
                             }
                         },
                         Required = new HashSet<string>
                         {
-                            "uploadedFile"
+                            uploadFileName
                         }
                     }
                 };


### PR DESCRIPTION
Hi Vitaly,

really appreciate your work towards this package. 

When implementing the `SwaggerUploadFileAttribute` I noticed, that the attribute properties `Name` and `Description` will not be used in the `FileUploadOperationFilter`. This results in the OpenAPI document and therefor also the SwaggerUI not displaying those values, but hardcoded values "uploadedFile" and "File to upload." respectively. 

This PR adds simple evaluation, if these properties are set and if so, using their values in the resulting OpenAPI document. 

Let me know if something is not right and I will happily adjust the code.

Cheers,
Boris