### PR TITLE
feat(polymorphism): Data Contract polymorphism in action

### DIFF
--- a/src/AzureFunctions.Extensions.Swashbuckle/TestFunction/Models/Shape.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/TestFunction/Models/Shape.cs
@@ -1,0 +1,53 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace TestFunction.Models
+{
+    /// <summary>
+    /// An abstract class for different shapes
+    /// <remarks>
+    /// $type: ["Circle", "Square", "Rectangle"]
+    /// </remarks>
+    /// </summary>
+    public abstract class Shape
+    {
+        /// <summary>
+        /// A globally unique identifier
+        /// </summary>
+        public string Name { get; set; }
+    }
+
+    /// <summary>
+    /// Circle
+    /// <remarks>
+    ///  $type: "Circle"
+    /// </remarks>
+    /// </summary>
+    public class Circle : Shape
+    {
+        public double Radius { get; set; }
+    }
+
+    /// <summary>
+    /// Square
+    /// <remarks>
+    ///  $type: "Square"
+    /// </remarks>
+    /// </summary>
+    public class Square : Shape
+    {
+        public double Side { get; set; }
+    }
+
+    /// <summary>
+    /// Square
+    /// <remarks>
+    ///  $type: "Rectangle"
+    /// </remarks>
+    /// </summary>
+    public class Rectangle : Shape
+    {
+        public double Length { get; set; }
+        public double Breadth { get; set; }
+    }
+}

--- a/src/AzureFunctions.Extensions.Swashbuckle/TestFunction/TestController.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/TestFunction/TestController.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using AzureFunctions.Extensions.Swashbuckle.Attribute;
 using Microsoft.AspNetCore.Http;
@@ -148,6 +149,18 @@ namespace TestFunction
             }
 
             return new NoContentResult();
+        }
+
+        [ProducesResponseType((int)HttpStatusCode.Accepted)]
+        [FunctionName("TestShape")]
+        [SupportedRequestFormat("application/json")]
+        public async Task<IActionResult> TestShape(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "test/shape")]
+            [RequestBodyType(typeof(Shape), "Shape")]
+            HttpRequestMessage httpRequest,
+            [SwaggerIgnore] CancellationToken cancellationToken = default)
+        {
+            return await Task.FromResult<IActionResult>(new OkResult());
         }
     }
 }

--- a/src/AzureFunctions.Extensions.Swashbuckle/TestFunction/TestFunction.csproj
+++ b/src/AzureFunctions.Extensions.Swashbuckle/TestFunction/TestFunction.csproj
@@ -7,7 +7,7 @@
     <DocumentationFile>TestFunction.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.11" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.13" />
     <PackageReference Include="System.Text.Json" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/AzureFunctions.Extensions.Swashbuckle/TestFunction/TestFunction.xml
+++ b/src/AzureFunctions.Extensions.Swashbuckle/TestFunction/TestFunction.xml
@@ -4,6 +4,43 @@
         <name>TestFunction</name>
     </assembly>
     <members>
+        <member name="T:TestFunction.Models.Shape">
+            <summary>
+            An abstract class for different shapes
+            <remarks>
+            $type: ["Circle", "Square", "Rectangle"]
+            </remarks>
+            </summary>
+        </member>
+        <member name="P:TestFunction.Models.Shape.Name">
+            <summary>
+            A globally unique identifier
+            </summary>
+        </member>
+        <member name="T:TestFunction.Models.Circle">
+            <summary>
+            Circle
+            <remarks>
+             $type: "Circle"
+            </remarks>
+            </summary>
+        </member>
+        <member name="T:TestFunction.Models.Square">
+            <summary>
+            Square
+            <remarks>
+             $type: "Square"
+            </remarks>
+            </summary>
+        </member>
+        <member name="T:TestFunction.Models.Rectangle">
+            <summary>
+            Square
+            <remarks>
+             $type: "Rectangle"
+            </remarks>
+            </summary>
+        </member>
         <member name="T:TestFunction.Models.TestModel">
             <summary>
             Some model


### PR DESCRIPTION
An example to demonstrate that swagger supports inheritance in data contracts.