### PR TITLE
Updated package version of Swashbuckle.AspNetCore and  Swashbuckle.As…

### DIFF
--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle.csproj
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle.csproj
@@ -21,8 +21,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.12" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.6.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.4.0" />
     <PackageReference Include="System.Text.Json" Version="4.7.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Updated package version of Swashbuckle.AspNetCore and  Swashbuckle.AspNetCore.Swagger to 6.4.0
Previous Version of Swashbuckle SwaggerUI (5.6.3) is vulnerable to a cross-site scripting vulnerability