### PR TITLE
Add support for Newtonsoft.Json in Swashbuckle

### DIFF
--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle.csproj
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle.csproj
@@ -21,8 +21,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.12" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.4.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.5.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.5.0" />
     <PackageReference Include="System.Text.Json" Version="6.0.6">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/Settings/SwaggerDocOptions.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/Settings/SwaggerDocOptions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using Microsoft.OpenApi;
@@ -27,6 +27,8 @@ namespace AzureFunctions.Extensions.Swashbuckle.Settings
         public string ClientId { get; set; } = "";
 
         public string OAuth2RedirectPath { get; set; } = "";
+
+        public bool AddNewtonsoftSupport { get; set; } = false;
 
     }
 }

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckle/SwashbuckleConfig.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckle/SwashbuckleConfig.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -123,6 +123,11 @@ namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle
             services.AddSingleton(_apiDescriptionGroupCollectionProvider);
 
             services.AddSingleton<IWebHostEnvironment>(new FunctionHostingEnvironment());
+
+            if (_swaggerOptions.AddNewtonsoftSupport)
+            {
+                services.AddSwaggerGenNewtonsoftSupport();
+            }
 
             services.AddSwaggerGen(options =>
             {

--- a/src/AzureFunctions.Extensions.Swashbuckle/TestFunction/SwashBuckleStartup.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/TestFunction/SwashBuckleStartup.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using AzureFunctions.Extensions.Swashbuckle;
@@ -23,6 +23,9 @@ namespace TestFunction
             //Register the extension
             builder.AddSwashBuckle(Assembly.GetExecutingAssembly(), opts =>
             {
+                // If you want to add Newtonsoft support insert next line
+                // opts.AddNewtonsoftSupport = true;
+
                 opts.SpecVersion = OpenApiSpecVersion.OpenApi3_0;
                 opts.AddCodeParameter = true;
                 opts.PrependOperationWithRoutePrefix = true;


### PR DESCRIPTION
This pull request enhances Swashbuckle to support Newtonsoft.Json library for Azure Functions. Currently, Swashbuckle does not recognize JsonProperty annotations in models. With this update, Swashbuckle now properly handles models annotated with JsonProperty.

Additionally, this update introduces a new feature to enable or disable Newtonsoft.Json support during Swashbuckle initialization in Azure Functions Startup. By setting the AddNewtonsoftSupport property to true, developers can activate support for Newtonsoft.Json. By default, Newtonsoft is disabled.

Example usage:

```csharp
builder.AddSwashBuckle(Assembly.GetExecutingAssembly(), opts =>
{
    opts.SpecVersion = OpenApiSpecVersion.OpenApi3_0;
    opts.AddCodeParameter = true;
    opts.PrependOperationWithRoutePrefix = true;
    
    // Enable Newtonsoft.Json support
    opts.AddNewtonsoftSupport = true;

    opts.Title = "Testing api";
    opts.ConfigureSwaggerGen = (x =>
    {
        x.CustomOperationIds(apiDesc =>
        {
            return apiDesc.TryGetMethodInfo(out MethodInfo methodInfo)
                ? methodInfo.Name
                : Guid.NewGuid().ToString();
        });
    });
});
```
This update provides more flexibility and compatibility for developers working with Azure Functions and Swashbuckle, ensuring seamless integration with Newtonsoft.Json serialization.