### PR TITLE
v5.0.0: Swashbuckle 10.x, OpenAPI v2, .NET 8/9, CI/CD

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,147 @@
+name: Auto-Release & Publish NuGet
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [master]
+    paths:
+      - 'src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle.csproj'
+
+permissions:
+  contents: write
+  packages: write
+
+env:
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_NOLOGO: true
+  NuGetDirectory: ${{github.workspace}}/nupkgs
+  CSPROJ_PATH: src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle.csproj
+
+jobs:
+  detect-version:
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.version-check.outputs.changed }}
+      current_version: ${{ steps.version-check.outputs.current_version }}
+      previous_version: ${{ steps.version-check.outputs.previous_version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Detect version change
+        id: version-check
+        run: |
+          CURRENT_VERSION=$(grep -oP '(?<=<Version>)[^<]*' ${{ env.CSPROJ_PATH }})
+          echo "current_version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+
+          PREVIOUS_VERSION=$(git show HEAD~1:${{ env.CSPROJ_PATH }} 2>/dev/null | grep -oP '(?<=<Version>)[^<]*' || echo "")
+          echo "previous_version=$PREVIOUS_VERSION" >> "$GITHUB_OUTPUT"
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Manual dispatch: forcing publish of $CURRENT_VERSION"
+          elif [ "$CURRENT_VERSION" != "$PREVIOUS_VERSION" ] && [ -n "$PREVIOUS_VERSION" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Version changed: $PREVIOUS_VERSION -> $CURRENT_VERSION"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No version change detected"
+          fi
+
+  create-release:
+    needs: detect-version
+    if: needs.detect-version.outputs.changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create GitHub Release
+        run: |
+          VERSION="${{ needs.detect-version.outputs.current_version }}"
+          PREV="${{ needs.detect-version.outputs.previous_version }}"
+          TAG="v$VERSION"
+
+          if gh release view "$TAG" > /dev/null 2>&1; then
+            echo "Release $TAG already exists, skipping"
+            exit 0
+          fi
+
+          gh release create "$TAG" \
+            --title "v$VERSION" \
+            --notes "## Changes
+
+          - Updated to Swashbuckle.AspNetCore 10.x / Microsoft.OpenApi v2
+          - Version bumped from $PREV to $VERSION
+
+          Published automatically to [NuGet](https://www.nuget.org/packages/AzureExtensions.Swashbuckle/$VERSION)." \
+            --target master
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-and-publish:
+    needs: [detect-version, create-release]
+    if: needs.detect-version.outputs.changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Build and Pack
+        run: |
+          VERSION="${{ needs.detect-version.outputs.current_version }}"
+          echo "Building and packing version: $VERSION"
+
+          dotnet build ${{ env.CSPROJ_PATH }} --configuration Release
+          dotnet pack ${{ env.CSPROJ_PATH }} --configuration Release \
+            --output ${{ env.NuGetDirectory }} \
+            /p:Version=$VERSION
+
+      - name: Validate NuGet package
+        run: |
+          dotnet tool update Meziantou.Framework.NuGetPackageValidation.Tool --global
+          meziantou.validate-nuget-package $(ls "${{ env.NuGetDirectory }}"/*.nupkg) --excluded-rules Symbols
+
+      - name: Publish to NuGet.org
+        run: |
+          for file in $(find ${{ env.NuGetDirectory }} -name "*.nupkg" ! -name "*.snupkg"); do
+            dotnet nuget push "$file" \
+              --api-key "${{ secrets.NUGET_PUSH_KEY }}" \
+              --source https://api.nuget.org/v3/index.json \
+              --skip-duplicate
+          done
+          for file in $(find ${{ env.NuGetDirectory }} -name "*.snupkg"); do
+            dotnet nuget push "$file" \
+              --api-key "${{ secrets.NUGET_PUSH_KEY }}" \
+              --source https://api.nuget.org/v3/index.json \
+              --skip-duplicate
+          done
+
+      - name: Publish to GitHub Packages
+        run: |
+          dotnet nuget add source \
+            --username ${{ github.repository_owner }} \
+            --password ${{ secrets.GITHUB_TOKEN }} \
+            --store-password-in-clear-text \
+            --name github \
+            "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
+
+          for file in $(find ${{ env.NuGetDirectory }} -name "*.nupkg" ! -name "*.snupkg"); do
+            dotnet nuget push "$file" \
+              --api-key ${{ secrets.GITHUB_TOKEN }} \
+              --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/" \
+              --skip-duplicate
+          done
+          for file in $(find ${{ env.NuGetDirectory }} -name "*.snupkg"); do
+            dotnet nuget push "$file" \
+              --api-key ${{ secrets.GITHUB_TOKEN }} \
+              --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/" \
+              --skip-duplicate
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,100 @@
+name: CI
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+env:
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_NOLOGO: true
+  SOLUTION_PATH: src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle.sln
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dotnet-version: ['8.0.x', '9.0.x']
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET ${{ matrix.dotnet-version }}
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ matrix.dotnet-version }}
+
+      - name: Restore dependencies
+        run: dotnet restore ${{ env.SOLUTION_PATH }}
+
+      - name: Build (Debug)
+        run: dotnet build ${{ env.SOLUTION_PATH }} --configuration Debug --no-restore
+
+      - name: Build (Release)
+        run: dotnet build ${{ env.SOLUTION_PATH }} --configuration Release --no-restore
+
+      - name: Run tests
+        run: |
+          dotnet test ${{ env.SOLUTION_PATH }} \
+            --configuration Release \
+            --no-build \
+            --logger "trx;LogFileName=test-results.trx" \
+            --results-directory ./test-results
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results-${{ matrix.dotnet-version }}
+          path: ./test-results/*.trx
+          retention-days: 30
+
+      - name: Process test results
+        if: always() && github.event_name == 'pull_request'
+        uses: im-open/process-dotnet-test-results@v3.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          base-directory: './test-results'
+          create-status-check: true
+          create-pr-comment: true
+          update-comment-if-one-exists: true
+          ignore-test-failures: false
+          comment-identifier: 'swashbuckle-tests-${{ matrix.dotnet-version }}'
+
+  pack:
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Pack NuGet
+        run: |
+          dotnet pack src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle.csproj \
+            --configuration Release \
+            --output ./nupkgs
+
+      - name: Validate NuGet package
+        run: |
+          dotnet tool update Meziantou.Framework.NuGetPackageValidation.Tool --global
+          meziantou.validate-nuget-package $(ls ./nupkgs/*.nupkg) --excluded-rules Symbols
+
+      - name: Upload NuGet artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: nuget-package
+          if-no-files-found: error
+          retention-days: 7
+          path: ./nupkgs/*

--- a/README.md
+++ b/README.md
@@ -1,311 +1,253 @@
+# AzureExtensions.Swashbuckle
 
-# AzureExtensions.Swashbuckle v4.0.0
+Swagger and Swagger UI for **Azure Functions** (isolated worker model) powered by Swashbuckle. Supports **OpenAPI 2.0, 3.0, and 3.1**.
 
-### (Searching for collaborators!)
+<p align="center">
 
-OpenAPI 2/3 implementation based on Swashbuckle(Swagger) tooling for API's built with Azure Functions 
+[![CI](https://github.com/vitalybibikov/AzureExtensions.Swashbuckle/actions/workflows/ci.yml/badge.svg)](https://github.com/vitalybibikov/AzureExtensions.Swashbuckle/actions/workflows/ci.yml)
+[![Auto-Release](https://github.com/vitalybibikov/AzureExtensions.Swashbuckle/actions/workflows/auto-release.yml/badge.svg)](https://github.com/vitalybibikov/AzureExtensions.Swashbuckle/actions/workflows/auto-release.yml)
+[![NuGet](https://img.shields.io/nuget/v/AzureExtensions.Swashbuckle?logo=nuget&label=NuGet)](https://www.nuget.org/packages/AzureExtensions.Swashbuckle)
+[![NuGet Downloads](https://img.shields.io/nuget/dt/AzureExtensions.Swashbuckle?logo=nuget&label=Downloads)](https://www.nuget.org/packages/AzureExtensions.Swashbuckle)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-This product aims to easily provide Swagger and Swagger UI of APIs created in Azure Functions using isolated worker model
+</p>
 
-------------------------------
-4.0.4
-- Updated to latest dependencies
+<p align="center">
 
-------------------------------
+![.NET 8](https://img.shields.io/badge/.NET-8.0_LTS-512BD4?logo=dotnet&logoColor=white)
+![.NET 9](https://img.shields.io/badge/.NET-9.0_STS-512BD4?logo=dotnet&logoColor=white)
+![Swashbuckle 10](https://img.shields.io/badge/Swashbuckle-10.x-85EA2D?logo=swagger&logoColor=white)
+![OpenAPI](https://img.shields.io/badge/OpenAPI-2.0_|_3.0_|_3.1-6BA539?logo=openapiinitiative&logoColor=white)
+![Azure Functions](https://img.shields.io/badge/Azure_Functions-Isolated_Worker-0062AD?logo=azurefunctions&logoColor=white)
 
-4.0.3
-by @MikeHookTransparity
-Added ClientSecret, UseBasicAuthenticationWithAccessCodeGrant
+</p>
 
-------------------------------
-4.0.2
-- Updated to latest Swagger 6.5.1
-- Fixes & Improvements
-- Added symbols package
+---
 
-------------------------------
-4.0.1
+## Features
 
-- Fixed some minor issues
-- Updated to new language features
-- Added exception handling and nullability
-- Doocumenation fixes
+- **Isolated Worker Model** — Built for Azure Functions v4 isolated worker (the recommended model going forward)
+- **Swashbuckle 10.x** — Latest Swashbuckle.AspNetCore with Microsoft.OpenApi v2 support
+- **OpenAPI 2.0 / 3.0 / 3.1** — Generate specs in any supported version
+- **Swagger UI** — Embedded Swagger UI served directly from your Azure Function
+- **Multi-document** — Define multiple API versions/documents
+- **XML Comments** — Automatic parameter and response documentation from XML docs
+- **Custom Attributes** — `[QueryStringParameter]`, `[RequestHttpHeader]`, `[SwaggerUploadFile]`, `[RequestBodyType]`
+- **OAuth2 Support** — Built-in OAuth2 redirect endpoint and client configuration
+- **Newtonsoft.Json** — Optional Newtonsoft serialization support
+- **Multi-targeting** — .NET 8.0 (LTS) and .NET 9.0 (STS)
 
-------------------------------
-4.0.0-beta
-- just remebering what the heck is going om here
-- Updated to v4 Functions
-- Updated to .NET 8
-- Updated to isolated worker model (from now on it is going to be the only one that is supported, as inprocess is going to be deprecated)
-- Updated to UI v5.17.3
-- Updated to Swagger 5.6.5
-- Updated docs
-- Considering removing support of NewtonJson
+---
 
-  https://www.nuget.org/packages/AzureExtensions.Swashbuckle/4.0.0-beta
-------------------------------
-3.3.1-beta
+## Installation
 
-- #64 Support for authorization configuration
-- #60 Consolidated extensions and added one to support .net 5
-- Updated docs
-- Updated js/html/css libs
-- Some classed made public to support 3-party IoC.
-- Fixed several issues, related to versioning and XML comments.
-- Updated to UI v3.37.2
-- Updated to Swagger 5.6.3
-- Updated documentation
-- Ability to create multiple versions of documents, example added.
-- Added examples of a custom filter, improved test application
-
-https://www.nuget.org/packages/AzureExtensions.Swashbuckle/4.0.0-beta
-
-
-------------------------------
-3.1.6
-
-https://www.nuget.org/packages/AzureExtensions.Swashbuckle/3.1.6
-
-Fixed #8, #9
-
-Updated to UI v3.25.1
-
-Updated to Swagger 5.4.1
-
-Fixed base url for Swagger UI
-
-**Breaking:**
-
-Option and DocumentOption renamed to SwaggerDocOptions and SwaggerDocument respectivly
-and moved to AzureFunctions.Extensions.Swashbuckle.Settings namespace
-
-**Properties renamed:**
-
-PrepandOperationWithRoutePrefix => PrependOperationWithRoutePrefix
-
-AddCodeParamater => AddCodeParameter
-
-**Properties added:**
-
-Added ability to configure SwaggerGen via ConfigureSwaggerGen
-
-Added ability to override default url to Swagger json document (in case of reverse proxy/gateway/ingress) are used.
-
-
-**Size:**
-
-All the resources are places in zip archive in order to decrease result dll size by 338% (from 1.594kb to 472kb)
-
-
-
-------------------------------
-3.0.0
-- Updated to v3 Functions
-- Updated to 5.0.0 Swashbuckle.AspNetCore nugets
-- Merged PRs to fix issues related to RequestBodyType and Ignore attribute
-- application/json is a default media type.
-
-
-
-# Sample
-
-https://github.com/vitalybibikov/azure-functions-extensions-swashbuckle/tree/master/src/AzureFunctions.Extensions.Swashbuckle/TestFunction
-
-# Update
-
-Version 3.0.0
-
-
-# Getting Started
-
-1. Install the standard Nuget package into your Azure Functions application.
-
-```
-Package Manager : Install-Package AzureExtensions.Swashbuckle
-CLI : dotnet add package AzureExtensions.Swashbuckle
+```bash
+dotnet add package AzureExtensions.Swashbuckle
 ```
 
-2. Add Program.cs class on your Functions project.
+## Quick Start
 
-!!! Now you need to specify in option the RoutePrefix.
-
-            opts.RoutePrefix = "api";
-
+### 1. Register the Extension in `Program.cs`
 
 ```csharp
-using System;
-using System.Collections.Generic;
-using Microsoft.Extensions.Hosting;
-using System.Reflection;
+using AzureFunctions.Extensions.Swashbuckle;
 using AzureFunctions.Extensions.Swashbuckle.Settings;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi;
-using Microsoft.OpenApi.Models;
-using AzureFunctions.Extensions.Swashbuckle;
-using Swashbuckle.AspNetCore.SwaggerGen;
 
 var host = new HostBuilder()
     .ConfigureServices((hostContext, services) =>
     {
-        //Register the extension
         services.AddSwashBuckle(opts =>
         {
-            // If you want to add Newtonsoft support insert next line
-            // opts.AddNewtonsoftSupport = true;
             opts.RoutePrefix = "api";
             opts.SpecVersion = OpenApiSpecVersion.OpenApi3_0;
             opts.AddCodeParameter = true;
             opts.PrependOperationWithRoutePrefix = true;
-            opts.XmlPath = "TestFunction.xml";
+            opts.XmlPath = "MyFunctionApp.xml";
             opts.Documents = new[]
             {
                 new SwaggerDocument
                 {
                     Name = "v1",
-                    Title = "Swagger document",
-                    Description = "Swagger test document",
-                    Version = "v2"
-                },
-                new SwaggerDocument
-                {
-                    Name = "v2",
-                    Title = "Swagger document 2",
-                    Description = "Swagger test document 2",
-                    Version = "v2"
+                    Title = "My API",
+                    Description = "My Azure Functions API",
+                    Version = "v1"
                 }
             };
-            opts.Title = "Swagger Test";
-            //opts.OverridenPathToSwaggerJson = new Uri("http://localhost:7071/api/Swagger/json");
-            opts.ConfigureSwaggerGen = x =>
-            {
-                //custom operation example
-                x.CustomOperationIds(apiDesc => apiDesc.TryGetMethodInfo(out MethodInfo methodInfo)
-                    ? methodInfo.Name
-                    : new Guid().ToString());
-
-                //custom filter example
-                //x.DocumentFilter<RemoveSchemasFilter>();
-
-                //oauth2
-                x.AddSecurityDefinition("oauth2",
-                    new OpenApiSecurityScheme
-                    {
-                        Type = SecuritySchemeType.OAuth2,
-                        Flows = new OpenApiOAuthFlows
-                        {
-                            Implicit = new OpenApiOAuthFlow
-                            {
-                                AuthorizationUrl = new Uri("https://your.idserver.net/connect/authorize"),
-                                Scopes = new Dictionary<string, string>
-                                {
-                                    { "api.read", "Access read operations" },
-                                    { "api.write", "Access write operations" }
-                                }
-                            }
-                        }
-                    });
-            };
-
-            // set up your client ID if your API is protected
-            opts.ClientId = "your.client.id";
-            opts.OAuth2RedirectPath = "http://localhost:7071/api/swagger/oauth2-redirect";
+            opts.Title = "My API";
         });
     })
     .Build();
 
 host.Run();
-
 ```
 
-3. Add swagger and swagger ui endpoint functions on your project.
+### 2. Add Swagger Endpoints
 
 ```csharp
-    public class SwaggerController
+public class SwaggerController
+{
+    private readonly ISwashBuckleClient swashBuckleClient;
+
+    public SwaggerController(ISwashBuckleClient swashBuckleClient)
     {
-        private readonly ISwashBuckleClient swashBuckleClient;
-
-        public SwaggerController(ISwashBuckleClient swashBuckleClient)
-        {
-            this.swashBuckleClient = swashBuckleClient;
-        }
-
-        [SwaggerIgnore]
-        [Function("SwaggerJson")]
-        public async Task<HttpResponseData> SwaggerJson(
-            [HttpTrigger(AuthorizationLevel.Function, "get", Route = "Swagger/json")]
-            HttpRequestData  req)
-        {
-            return await this.swashBuckleClient.CreateSwaggerJsonDocumentResponse(req);
-        }
-
-        [SwaggerIgnore]
-        [Function("SwaggerYaml")]
-        public async Task<HttpResponseData> SwaggerYaml(
-            [HttpTrigger(AuthorizationLevel.Function, "get", Route = "Swagger/yaml")]
-            HttpRequestData req)
-        {
-            return await this.swashBuckleClient.CreateSwaggerYamlDocumentResponse(req);
-        }
-
-        [SwaggerIgnore]
-        [Function("SwaggerUi")]
-        public async Task<HttpResponseData> SwaggerUi(
-            [HttpTrigger(AuthorizationLevel.Function, "get", Route = "Swagger/ui")]
-            HttpRequestData req)
-        {
-            return await this.swashBuckleClient.CreateSwaggerUIResponse(req, "swagger/json");
-        }
-
-        /// <summary>
-        /// This is only needed for OAuth2 client. This redirecting document is normally served
-        /// as a static content. Functions don't provide this out of the box, so we serve it here.
-        /// Don't forget to set OAuth2RedirectPath configuration option to reflect this route.
-        /// </summary>
-        /// <param name="req"></param>
-        /// <param name="swashBuckleClient"></param>
-        /// <returns></returns>
-        [SwaggerIgnore]
-        [Function("SwaggerOAuth2Redirect")]
-        public async Task<HttpResponseData> SwaggerOAuth2Redirect(
-            [HttpTrigger(AuthorizationLevel.Function, "get", Route = "swagger/oauth2-redirect")]
-            HttpRequestData req)
-        {
-            return await this.swashBuckleClient.CreateSwaggerOAuth2RedirectResponse(req);
-        }
+        this.swashBuckleClient = swashBuckleClient;
     }
+
+    [SwaggerIgnore]
+    [Function("SwaggerJson")]
+    public async Task<HttpResponseData> SwaggerJson(
+        [HttpTrigger(AuthorizationLevel.Function, "get", Route = "Swagger/json")]
+        HttpRequestData req)
+    {
+        return await this.swashBuckleClient.CreateSwaggerJsonDocumentResponse(req);
+    }
+
+    [SwaggerIgnore]
+    [Function("SwaggerYaml")]
+    public async Task<HttpResponseData> SwaggerYaml(
+        [HttpTrigger(AuthorizationLevel.Function, "get", Route = "Swagger/yaml")]
+        HttpRequestData req)
+    {
+        return await this.swashBuckleClient.CreateSwaggerYamlDocumentResponse(req);
+    }
+
+    [SwaggerIgnore]
+    [Function("SwaggerUi")]
+    public async Task<HttpResponseData> SwaggerUi(
+        [HttpTrigger(AuthorizationLevel.Function, "get", Route = "Swagger/ui")]
+        HttpRequestData req)
+    {
+        return await this.swashBuckleClient.CreateSwaggerUIResponse(req, "swagger/json");
+    }
+}
 ```
 
-4. Open Swagger UI URL in your browser.
+### 3. Open Swagger UI
 
-If you does not changed api route prefix. Swagger UI URL is https://hostname/api/swagger/ui .
+Navigate to `https://your-function-app/api/swagger/ui` in your browser.
 
-## Options
+---
 
-### Include Xml document file
+## Configuration Options
 
-AzureFunctions.Extensions.Swashbuckle can include xml document file.
+### XML Documentation
 
-1. Change your functions project's GenerateDocumentationFile option to enable.
+Enable XML doc generation in your `.csproj`:
 
-            builder.AddSwashBuckle(Assembly.GetExecutingAssembly(), opts =>
+```xml
+<PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+</PropertyGroup>
+```
+
+Then pass the XML path:
+
+```csharp
+opts.XmlPath = "MyFunctionApp.xml";
+```
+
+### Multiple Documents
+
+```csharp
+opts.Documents = new[]
+{
+    new SwaggerDocument { Name = "v1", Title = "API v1", Version = "v1" },
+    new SwaggerDocument { Name = "v2", Title = "API v2", Version = "v2" }
+};
+```
+
+### OAuth2
+
+```csharp
+opts.ConfigureSwaggerGen = x =>
+{
+    x.AddSecurityDefinition("oauth2", new OpenApiSecurityScheme
+    {
+        Type = SecuritySchemeType.OAuth2,
+        Flows = new OpenApiOAuthFlows
+        {
+            Implicit = new OpenApiOAuthFlow
             {
-                opts.XmlPath = "TestFunction.xml";
-            });
+                AuthorizationUrl = new Uri("https://your.idserver.net/connect/authorize"),
+                Scopes = new Dictionary<string, string>
+                {
+                    { "api.read", "Access read operations" },
+                    { "api.write", "Access write operations" }
+                }
+            }
+        }
+    });
+};
 
-2. Add configration setting this extensions on your functions project's local.settings.json
-
-```json
-  "SwaggerDocOptions": {
-    "XmlPath": "TestFunction.xml"
-  }
+opts.ClientId = "your.client.id";
+opts.OAuth2RedirectPath = "http://localhost:7071/api/swagger/oauth2-redirect";
 ```
 
-Alternatively you can add this section to your host.json
+### Custom Attributes
 
-```json
-  "extensions": {
-    "Swashbuckle": {
-      "XmlPath": "TestFunction.xml"
-    }
-  }
+```csharp
+// Add query string parameters
+[QueryStringParameter("page", "Page number", DataType = typeof(int), Required = false)]
+[Function("GetItems")]
+public async Task<HttpResponseData> GetItems(...)
+
+// Add required HTTP headers
+[RequestHttpHeader("X-Api-Key", isRequired: true)]
+[Function("SecureEndpoint")]
+public async Task<HttpResponseData> SecureEndpoint(...)
+
+// File upload
+[SwaggerUploadFile("file", "File to upload")]
+[Function("Upload")]
+public async Task<HttpResponseData> Upload(...)
 ```
+
+### Newtonsoft.Json Support
+
+```csharp
+services.AddSwashBuckle(opts =>
+{
+    opts.AddNewtonsoftSupport = true;
+    // ...
+});
+```
+
+---
+
+## Migration from v4.x to v5.x
+
+v5.0 includes breaking changes due to the Swashbuckle 10.x / Microsoft.OpenApi v2 upgrade:
+
+| Change | v4.x | v5.x |
+|--------|------|------|
+| Swagger document methods | Synchronous | **Async** (`GetSwaggerJsonDocumentAsync`) |
+| OpenAPI schema types | `Type = "string"` | `Type = JsonSchemaType.String` |
+| Nullable schemas | `Nullable = true` | `JsonSchemaType.X \| JsonSchemaType.Null` |
+| OpenAPI namespace | `Microsoft.OpenApi.Models` | `Microsoft.OpenApi` |
+
+### Async Document Methods
+
+```csharp
+// v4.x
+Stream json = client.GetSwaggerJsonDocument(req, "v1");
+
+// v5.x
+Stream json = await client.GetSwaggerJsonDocumentAsync(req, "v1");
+```
+
+---
+
+## Sample Project
+
+See the [TestFunction](https://github.com/vitalybibikov/AzureExtensions.Swashbuckle/tree/master/src/AzureFunctions.Extensions.Swashbuckle/TestFunction) project for a complete working example.
+
+## Contributing
+
+Contributions are welcome! Please open an issue or submit a pull request.
+
+## License
+
+Copyright &copy; 2026, Vitali Bibikov. Code released under the [MIT License](LICENSE).

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle.Tests/AzureFunctions.Extensions.Swashbuckle.Tests.csproj
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle.Tests/AzureFunctions.Extensions.Swashbuckle.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="FluentAssertions" Version="8.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AzureFunctions.Extensions.Swashbuckle\AzureFunctions.Extensions.Swashbuckle.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle.Tests/FileUploadOperationFilterTests.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle.Tests/FileUploadOperationFilterTests.cs
@@ -1,0 +1,117 @@
+// Copyright (c) Vitaly Bibikov. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Reflection;
+using AzureFunctions.Extensions.Swashbuckle.Attribute;
+using AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters;
+using FluentAssertions;
+using Microsoft.OpenApi;
+
+using Swashbuckle.AspNetCore.SwaggerGen;
+using Xunit;
+
+namespace AzureFunctions.Extensions.Swashbuckle.Tests;
+
+public class FileUploadOperationFilterTests
+{
+    private readonly FileUploadOperationFilter _filter = new();
+
+    [Fact]
+    public void Apply_MethodWithSwaggerUploadFileAttribute_ProducesMultipartSchema()
+    {
+        var operation = new OpenApiOperation();
+        var context = CreateOperationFilterContext(nameof(TestEndpoints.UploadFile));
+
+        _filter.Apply(operation, context);
+
+        operation.RequestBody.Should().NotBeNull();
+        operation.RequestBody!.Content.Should().ContainKey("multipart/form-data");
+
+        var mediaType = operation.RequestBody.Content["multipart/form-data"];
+        mediaType.Schema.Should().NotBeNull();
+        mediaType.Schema!.Type.Should().Be(JsonSchemaType.Object);
+        mediaType.Schema.Properties.Should().ContainKey("uploadedFile");
+
+        var fileProperty = mediaType.Schema.Properties["uploadedFile"] as OpenApiSchema;
+        fileProperty.Should().NotBeNull();
+        fileProperty!.Type.Should().Be(JsonSchemaType.String);
+        fileProperty.Format.Should().Be("binary");
+        fileProperty.Description.Should().Be("File to upload.");
+    }
+
+    [Fact]
+    public void Apply_MethodWithoutAttribute_IsNoOp()
+    {
+        var operation = new OpenApiOperation();
+        var context = CreateOperationFilterContext(nameof(TestEndpoints.NoUpload));
+
+        _filter.Apply(operation, context);
+
+        operation.RequestBody.Should().BeNull();
+    }
+
+    [Fact]
+    public void Apply_MethodWithCustomFileNameAndDescription_UsesCustomValues()
+    {
+        var operation = new OpenApiOperation();
+        var context = CreateOperationFilterContext(nameof(TestEndpoints.CustomUpload));
+
+        _filter.Apply(operation, context);
+
+        operation.RequestBody.Should().NotBeNull();
+        var mediaType = operation.RequestBody!.Content["multipart/form-data"];
+        mediaType.Schema!.Properties.Should().ContainKey("myDocument");
+        mediaType.Schema.Required.Should().Contain("myDocument");
+
+        var fileProperty = mediaType.Schema.Properties["myDocument"] as OpenApiSchema;
+        fileProperty.Should().NotBeNull();
+        fileProperty!.Description.Should().Be("PDF document to process");
+    }
+
+    [Fact]
+    public void Apply_MethodWithExampleSet_SetsExampleOnSchema()
+    {
+        var operation = new OpenApiOperation();
+        var context = CreateOperationFilterContext(nameof(TestEndpoints.UploadWithExample));
+
+        _filter.Apply(operation, context);
+
+        operation.RequestBody.Should().NotBeNull();
+        var mediaType = operation.RequestBody!.Content["multipart/form-data"];
+        var schema = mediaType.Schema as OpenApiSchema;
+        schema.Should().NotBeNull();
+        schema!.Example.Should().NotBeNull();
+    }
+
+    private static OperationFilterContext CreateOperationFilterContext(string methodName)
+    {
+        var methodInfo = typeof(TestEndpoints).GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance)!;
+        var schemaGeneratorOptions = new SchemaGeneratorOptions();
+        var schemaGenerator = new SchemaGenerator(schemaGeneratorOptions, new JsonSerializerDataContractResolver(new System.Text.Json.JsonSerializerOptions()));
+        var schemaRepository = new SchemaRepository();
+        var document = new OpenApiDocument();
+
+        return new OperationFilterContext(
+            new Microsoft.AspNetCore.Mvc.ApiExplorer.ApiDescription(),
+            schemaGenerator,
+            schemaRepository,
+            document,
+            methodInfo);
+    }
+
+    // Test endpoint stubs
+
+    private class TestEndpoints
+    {
+        [SwaggerUploadFile("uploadedFile", "File to upload.")]
+        public void UploadFile() { }
+
+        public void NoUpload() { }
+
+        [SwaggerUploadFile("myDocument", "PDF document to process")]
+        public void CustomUpload() { }
+
+        [SwaggerUploadFile("report", "Report file", "sample.pdf")]
+        public void UploadWithExample() { }
+    }
+}

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle.Tests/FunctionsOperationFilterTests.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle.Tests/FunctionsOperationFilterTests.cs
@@ -1,0 +1,179 @@
+// Copyright (c) Vitaly Bibikov. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Reflection;
+using AzureFunctions.Extensions.Swashbuckle.Attribute;
+using AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters;
+using FluentAssertions;
+using Microsoft.OpenApi;
+
+using Swashbuckle.AspNetCore.SwaggerGen;
+using Xunit;
+
+namespace AzureFunctions.Extensions.Swashbuckle.Tests;
+
+public class FunctionsOperationFilterTests
+{
+    private readonly FunctionsOperationFilter _filter = new();
+
+    [Fact]
+    public void Apply_MethodWithRequestHttpHeaderAttribute_AddsHeaderParameter()
+    {
+        var operation = new OpenApiOperation();
+        var context = CreateOperationFilterContext(
+            typeof(MethodLevelHeaderEndpoints),
+            nameof(MethodLevelHeaderEndpoints.WithHeader));
+
+        _filter.Apply(operation, context);
+
+        operation.Parameters.Should().HaveCount(1);
+        var param = operation.Parameters[0] as OpenApiParameter;
+        param.Should().NotBeNull();
+        param!.Name.Should().Be("X-Custom-Header");
+        param.In.Should().Be(ParameterLocation.Header);
+        param.Schema.Should().NotBeNull();
+        (param.Schema as OpenApiSchema)!.Type.Should().Be(JsonSchemaType.String);
+        param.Required.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Apply_ClassLevelRequestHttpHeaderAttribute_AddsHeaderParameter()
+    {
+        var operation = new OpenApiOperation();
+        var context = CreateOperationFilterContext(
+            typeof(ClassLevelHeaderEndpoints),
+            nameof(ClassLevelHeaderEndpoints.SomeMethod));
+
+        _filter.Apply(operation, context);
+
+        operation.Parameters.Should().ContainSingle();
+        var param = operation.Parameters[0] as OpenApiParameter;
+        param.Should().NotBeNull();
+        param!.Name.Should().Be("X-Api-Key");
+        param.In.Should().Be(ParameterLocation.Header);
+        param.Required.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Apply_RequiredHeader_SetsRequiredTrue()
+    {
+        var operation = new OpenApiOperation();
+        var context = CreateOperationFilterContext(
+            typeof(RequiredHeaderEndpoints),
+            nameof(RequiredHeaderEndpoints.RequiredHeaderMethod));
+
+        _filter.Apply(operation, context);
+
+        operation.Parameters.Should().HaveCount(1);
+        var param = operation.Parameters[0] as OpenApiParameter;
+        param!.Required.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Apply_OptionalHeader_SetsRequiredFalse()
+    {
+        var operation = new OpenApiOperation();
+        var context = CreateOperationFilterContext(
+            typeof(MethodLevelHeaderEndpoints),
+            nameof(MethodLevelHeaderEndpoints.WithHeader));
+
+        _filter.Apply(operation, context);
+
+        var param = operation.Parameters[0] as OpenApiParameter;
+        param!.Required.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Apply_MultipleMethodHeaders_AddsAllParameters()
+    {
+        var operation = new OpenApiOperation();
+        var context = CreateOperationFilterContext(
+            typeof(MultipleHeaderEndpoints),
+            nameof(MultipleHeaderEndpoints.MultipleHeaders));
+
+        _filter.Apply(operation, context);
+
+        operation.Parameters.Should().HaveCount(2);
+        operation.Parameters.Cast<OpenApiParameter>().Select(p => p.Name)
+            .Should().Contain(new[] { "X-First", "X-Second" });
+    }
+
+    [Fact]
+    public void Apply_MethodAndClassHeaders_AddsBoth()
+    {
+        var operation = new OpenApiOperation();
+        var context = CreateOperationFilterContext(
+            typeof(ClassLevelHeaderEndpoints),
+            nameof(ClassLevelHeaderEndpoints.MethodWithAdditionalHeader));
+
+        _filter.Apply(operation, context);
+
+        operation.Parameters.Should().HaveCount(2);
+        operation.Parameters.Cast<OpenApiParameter>().Select(p => p.Name)
+            .Should().Contain(new[] { "X-Api-Key", "X-Extra" });
+    }
+
+    [Fact]
+    public void Apply_NoAttributes_ParametersListIsEmpty()
+    {
+        var operation = new OpenApiOperation();
+        var context = CreateOperationFilterContext(
+            typeof(NoHeaderEndpoints),
+            nameof(NoHeaderEndpoints.PlainMethod));
+
+        _filter.Apply(operation, context);
+
+        operation.Parameters.Should().BeEmpty();
+    }
+
+    private static OperationFilterContext CreateOperationFilterContext(Type declaringType, string methodName)
+    {
+        var methodInfo = declaringType.GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance)!;
+        var schemaGeneratorOptions = new SchemaGeneratorOptions();
+        var schemaGenerator = new SchemaGenerator(schemaGeneratorOptions, new JsonSerializerDataContractResolver(new System.Text.Json.JsonSerializerOptions()));
+        var schemaRepository = new SchemaRepository();
+        var document = new OpenApiDocument();
+
+        return new OperationFilterContext(
+            new Microsoft.AspNetCore.Mvc.ApiExplorer.ApiDescription(),
+            schemaGenerator,
+            schemaRepository,
+            document,
+            methodInfo);
+    }
+
+    // Test endpoint stubs
+
+    private class MethodLevelHeaderEndpoints
+    {
+        [RequestHttpHeader("X-Custom-Header")]
+        public void WithHeader() { }
+    }
+
+    [RequestHttpHeader("X-Api-Key", isRequired: true)]
+    private class ClassLevelHeaderEndpoints
+    {
+        public void SomeMethod() { }
+
+        [RequestHttpHeader("X-Extra")]
+        public void MethodWithAdditionalHeader() { }
+    }
+
+    private class RequiredHeaderEndpoints
+    {
+        [RequestHttpHeader("Authorization", isRequired: true)]
+        public void RequiredHeaderMethod() { }
+    }
+
+    private class MultipleHeaderEndpoints
+    {
+        [RequestHttpHeader("X-First")]
+        [RequestHttpHeader("X-Second", isRequired: true)]
+        public void MultipleHeaders() { }
+    }
+
+    private class NoHeaderEndpoints
+    {
+        public void PlainMethod() { }
+    }
+}

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle.Tests/JsonMapperTests.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle.Tests/JsonMapperTests.cs
@@ -1,0 +1,142 @@
+// Copyright (c) Vitaly Bibikov. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json.Nodes;
+using AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters.Mapper;
+using FluentAssertions;
+using Xunit;
+
+namespace AzureFunctions.Extensions.Swashbuckle.Tests;
+
+/// <summary>
+/// Tests for <see cref="JsonMapper.CreateFromJson"/>.
+/// The method serializes the input string via JsonSerializer.Serialize (wrapping it in quotes),
+/// then deserializes to JsonElement. Because the input is always a C# string, the deserialized
+/// JsonElement is always ValueKind.String — so boolean/number branches are only reachable
+/// through the recursive array element path where raw JSON tokens are passed back in.
+/// </summary>
+public class JsonMapperTests
+{
+    [Fact]
+    public void CreateFromJson_BooleanLiteral_ReturnedAsString()
+    {
+        // "true" is a C# string → Serialize wraps it → deserialized as String kind
+        var result = JsonMapper.CreateFromJson("true");
+
+        result.Should().NotBeNull();
+        result!.GetValue<string>().Should().Be("true");
+    }
+
+    [Fact]
+    public void CreateFromJson_IntegerLiteral_ReturnedAsString()
+    {
+        // "42" is a C# string → Serialize wraps it → deserialized as String kind
+        var result = JsonMapper.CreateFromJson("42");
+
+        result.Should().NotBeNull();
+        result!.GetValue<string>().Should().Be("42");
+    }
+
+    [Fact]
+    public void CreateFromJson_FloatLiteral_ReturnedAsString()
+    {
+        var result = JsonMapper.CreateFromJson("3.14");
+
+        result.Should().NotBeNull();
+        result!.GetValue<string>().Should().Be("3.14");
+    }
+
+    [Fact]
+    public void CreateFromJson_PlainString_ReturnedAsString()
+    {
+        var result = JsonMapper.CreateFromJson("hello world");
+
+        result.Should().NotBeNull();
+        result!.GetValue<string>().Should().Be("hello world");
+    }
+
+    [Fact]
+    public void CreateFromJson_NullLiteral_ReturnedAsString()
+    {
+        // "null" is a C# string → Serialize wraps → deserialized as String "null"
+        var result = JsonMapper.CreateFromJson("null");
+
+        result.Should().NotBeNull();
+        result!.GetValue<string>().Should().Be("null");
+    }
+
+    [Fact]
+    public void CreateFromJson_EmptyString_ReturnedAsEmptyString()
+    {
+        var result = JsonMapper.CreateFromJson("");
+
+        result.Should().NotBeNull();
+        result!.GetValue<string>().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CreateFromJson_NegativeNumber_ReturnedAsString()
+    {
+        var result = JsonMapper.CreateFromJson("-10");
+
+        result.Should().NotBeNull();
+        result!.GetValue<string>().Should().Be("-10");
+    }
+
+    [Fact]
+    public void CreateFromJson_StringWithSpecialChars_ReturnedCorrectly()
+    {
+        var result = JsonMapper.CreateFromJson("hello \"world\"");
+
+        result.Should().NotBeNull();
+        result!.GetValue<string>().Should().Be("hello \"world\"");
+    }
+
+    [Fact]
+    public void CreateFromJson_ArrayLiteral_ReturnedAsString()
+    {
+        // "[1, 2, 3]" is a C# string → Serialize wraps it → deserialized as String kind
+        var result = JsonMapper.CreateFromJson("[1, 2, 3]");
+
+        result.Should().NotBeNull();
+        result!.GetValue<string>().Should().Be("[1, 2, 3]");
+    }
+
+    [Fact]
+    public void CreateFromJson_LongNumberLiteral_ReturnedAsString()
+    {
+        var longValue = ((long)int.MaxValue + 1).ToString();
+        var result = JsonMapper.CreateFromJson(longValue);
+
+        result.Should().NotBeNull();
+        result!.GetValue<string>().Should().Be(longValue);
+    }
+
+    [Fact]
+    public void CreateFromJson_UnicodeString_ReturnedCorrectly()
+    {
+        var result = JsonMapper.CreateFromJson("\u00e9\u00e0\u00fc");
+
+        result.Should().NotBeNull();
+        result!.GetValue<string>().Should().Be("\u00e9\u00e0\u00fc");
+    }
+
+    [Fact]
+    public void CreateFromJson_WhitespaceOnly_ReturnedAsString()
+    {
+        var result = JsonMapper.CreateFromJson("   ");
+
+        result.Should().NotBeNull();
+        result!.GetValue<string>().Should().Be("   ");
+    }
+
+    [Fact]
+    public void CreateFromJson_VeryLongString_ReturnedCorrectly()
+    {
+        var longString = new string('x', 10000);
+        var result = JsonMapper.CreateFromJson(longString);
+
+        result.Should().NotBeNull();
+        result!.GetValue<string>().Should().Be(longString);
+    }
+}

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle.Tests/QueryStringParameterAttributeTests.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle.Tests/QueryStringParameterAttributeTests.cs
@@ -1,0 +1,124 @@
+// Copyright (c) Vitaly Bibikov. All rights reserved.
+// Licensed under the MIT License.
+
+using AzureFunctions.Extensions.Swashbuckle.Attribute;
+using FluentAssertions;
+using Xunit;
+
+namespace AzureFunctions.Extensions.Swashbuckle.Tests;
+
+public class QueryStringParameterAttributeTests
+{
+    [Fact]
+    public void Constructor_WithNameAndDescription_SetsPropertiesCorrectly()
+    {
+        var attr = new QueryStringParameterAttribute("page", "Page number");
+
+        attr.Name.Should().Be("page");
+        attr.Description.Should().Be("Page number");
+        attr.Example.Should().BeNull();
+        attr.Required.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Constructor_WithStringExample_SetsJsonValueString()
+    {
+        var attr = new QueryStringParameterAttribute("name", "User name", "John");
+
+        attr.Name.Should().Be("name");
+        attr.Description.Should().Be("User name");
+        attr.DataType.Should().Be(typeof(string));
+        attr.Example.Should().NotBeNull();
+        attr.Example!.GetValue<string>().Should().Be("John");
+    }
+
+    [Fact]
+    public void Constructor_WithIntExample_SetsJsonValueInt()
+    {
+        var attr = new QueryStringParameterAttribute("page", "Page number", 5);
+
+        attr.Name.Should().Be("page");
+        attr.Description.Should().Be("Page number");
+        attr.DataType.Should().Be(typeof(int));
+        attr.Example.Should().NotBeNull();
+        attr.Example!.GetValue<int>().Should().Be(5);
+    }
+
+    [Fact]
+    public void Constructor_WithBoolExample_SetsJsonValueBool()
+    {
+        var attr = new QueryStringParameterAttribute("active", "Is active", true);
+
+        attr.Name.Should().Be("active");
+        attr.Description.Should().Be("Is active");
+        attr.DataType.Should().Be(typeof(bool));
+        attr.Example.Should().NotBeNull();
+        attr.Example!.GetValue<bool>().Should().BeTrue();
+    }
+
+    [Fact]
+    public void Constructor_WithFloatExample_SetsJsonValueFloat()
+    {
+        var attr = new QueryStringParameterAttribute("ratio", "Ratio value", 1.5f);
+
+        attr.Name.Should().Be("ratio");
+        attr.Description.Should().Be("Ratio value");
+        attr.DataType.Should().Be(typeof(float));
+        attr.Example.Should().NotBeNull();
+        attr.Example!.GetValue<float>().Should().Be(1.5f);
+    }
+
+    [Fact]
+    public void Constructor_WithDoubleExample_SetsJsonValueDouble()
+    {
+        var attr = new QueryStringParameterAttribute("price", "Price value", 99.99);
+
+        attr.Name.Should().Be("price");
+        attr.Description.Should().Be("Price value");
+        attr.Example.Should().NotBeNull();
+        attr.Example!.GetValue<double>().Should().Be(99.99);
+    }
+
+    [Fact]
+    public void Constructor_WithLongExample_SetsJsonValueLong()
+    {
+        var attr = new QueryStringParameterAttribute("id", "Record ID", 9876543210L);
+
+        attr.Name.Should().Be("id");
+        attr.Description.Should().Be("Record ID");
+        attr.DataType.Should().Be(typeof(long));
+        attr.Example.Should().NotBeNull();
+        attr.Example!.GetValue<long>().Should().Be(9876543210L);
+    }
+
+    [Fact]
+    public void Constructor_WithByteExample_SetsJsonValueByte()
+    {
+        var attr = new QueryStringParameterAttribute("level", "Level value", (byte)128);
+
+        attr.Name.Should().Be("level");
+        attr.Description.Should().Be("Level value");
+        attr.DataType.Should().Be(typeof(byte));
+        attr.Example.Should().NotBeNull();
+        attr.Example!.GetValue<byte>().Should().Be(128);
+    }
+
+    [Fact]
+    public void Required_DefaultsToFalse()
+    {
+        var attr = new QueryStringParameterAttribute("test", "Test param");
+
+        attr.Required.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Required_CanBeSetToTrue()
+    {
+        var attr = new QueryStringParameterAttribute("test", "Test param")
+        {
+            Required = true
+        };
+
+        attr.Required.Should().BeTrue();
+    }
+}

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle.Tests/SwashBuckleStartupExtensionTests.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle.Tests/SwashBuckleStartupExtensionTests.cs
@@ -1,0 +1,149 @@
+// Copyright (c) Vitaly Bibikov. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Reflection;
+using AzureFunctions.Extensions.Swashbuckle.Settings;
+using AzureFunctions.Extensions.Swashbuckle.SwashBuckle;
+using AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Providers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace AzureFunctions.Extensions.Swashbuckle.Tests;
+
+public class SwashBuckleStartupExtensionTests
+{
+    [Fact]
+    public void AddSwashBuckle_RegistersISwashBuckleClient()
+    {
+        var services = new ServiceCollection();
+        services.AddOptions();
+
+        services.AddSwashBuckle(executingAssembly: Assembly.GetExecutingAssembly());
+
+        services.Should().Contain(sd =>
+            sd.ServiceType == typeof(ISwashBuckleClient) &&
+            sd.ImplementationType == typeof(SwashBuckleClient) &&
+            sd.Lifetime == ServiceLifetime.Singleton);
+    }
+
+    [Fact]
+    public void AddSwashBuckle_RegistersSwashbuckleConfig()
+    {
+        var services = new ServiceCollection();
+        services.AddOptions();
+
+        services.AddSwashBuckle(executingAssembly: Assembly.GetExecutingAssembly());
+
+        services.Should().Contain(sd =>
+            sd.ServiceType == typeof(SwashbuckleConfig) &&
+            sd.Lifetime == ServiceLifetime.Singleton);
+    }
+
+    [Fact]
+    public void AddSwashBuckle_WithOptions_ConfiguresSwaggerDocOptions()
+    {
+        var services = new ServiceCollection();
+        services.AddOptions();
+
+        services.AddSwashBuckle(
+            configureDocOptionsAction: options =>
+            {
+                options.Title = "My Test API";
+                options.RoutePrefix = "swagger";
+            },
+            executingAssembly: Assembly.GetExecutingAssembly());
+
+        var provider = services.BuildServiceProvider();
+        var optionsMonitor = provider.GetService<IOptions<SwaggerDocOptions>>();
+        optionsMonitor.Should().NotBeNull();
+        optionsMonitor!.Value.Title.Should().Be("My Test API");
+        optionsMonitor.Value.RoutePrefix.Should().Be("swagger");
+    }
+
+    [Fact]
+    public void AddSwashBuckle_ReturnsServiceCollectionForChaining()
+    {
+        var services = new ServiceCollection();
+        services.AddOptions();
+
+        var result = services.AddSwashBuckle(executingAssembly: Assembly.GetExecutingAssembly());
+
+        result.Should().BeSameAs(services);
+    }
+
+    [Fact]
+    public void AddSwashBuckle_WithoutOptions_UsesDefaultConfiguration()
+    {
+        var services = new ServiceCollection();
+        services.AddOptions();
+
+        services.AddSwashBuckle(executingAssembly: Assembly.GetExecutingAssembly());
+
+        var provider = services.BuildServiceProvider();
+        var optionsMonitor = provider.GetService<IOptions<SwaggerDocOptions>>();
+        optionsMonitor.Should().NotBeNull();
+        optionsMonitor!.Value.AddCodeParameter.Should().BeTrue();
+        optionsMonitor.Value.PrependOperationWithRoutePrefix.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AddSwashBuckle_RegistersModelMetadataProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddOptions();
+
+        services.AddSwashBuckle(executingAssembly: Assembly.GetExecutingAssembly());
+
+        var provider = services.BuildServiceProvider();
+        var metadataProvider = provider.GetService<IModelMetadataProvider>();
+        metadataProvider.Should().NotBeNull();
+        metadataProvider.Should().BeOfType<EmptyModelMetadataProvider>();
+    }
+
+    [Fact]
+    public void AddSwashBuckle_RegistersOutputFormatter()
+    {
+        var services = new ServiceCollection();
+        services.AddOptions();
+
+        services.AddSwashBuckle(executingAssembly: Assembly.GetExecutingAssembly());
+
+        var provider = services.BuildServiceProvider();
+        var formatter = provider.GetService<IOutputFormatter>();
+        formatter.Should().NotBeNull();
+        formatter.Should().BeOfType<SystemTextJsonOutputFormatter>();
+    }
+
+    [Fact]
+    public void AddSwashBuckle_RegistersApiDescriptionProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddOptions();
+
+        services.AddSwashBuckle(executingAssembly: Assembly.GetExecutingAssembly());
+
+        services.Should().Contain(sd =>
+            sd.ServiceType == typeof(IApiDescriptionGroupCollectionProvider) &&
+            sd.Lifetime == ServiceLifetime.Singleton);
+    }
+
+    [Fact]
+    public void AddSwashBuckle_RegistersStartupConfig()
+    {
+        var services = new ServiceCollection();
+        services.AddOptions();
+        var assembly = Assembly.GetExecutingAssembly();
+
+        services.AddSwashBuckle(executingAssembly: assembly);
+
+        var provider = services.BuildServiceProvider();
+        var startupConfig = provider.GetService<SwashBuckleStartupConfig>();
+        startupConfig.Should().NotBeNull();
+        startupConfig!.Assembly.Should().BeSameAs(assembly);
+    }
+}

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle.Tests/TypeMapperTests.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle.Tests/TypeMapperTests.cs
@@ -1,0 +1,312 @@
+// Copyright (c) Vitaly Bibikov. All rights reserved.
+// Licensed under the MIT License.
+
+using AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters.Mapper;
+using FluentAssertions;
+using Microsoft.OpenApi;
+using Xunit;
+
+namespace AzureFunctions.Extensions.Swashbuckle.Tests;
+
+public class TypeMapperTests
+{
+    [Fact]
+    public void ToOpenApiSpecType_Bool_ReturnsBooleanType()
+    {
+        var schema = typeof(bool).ToOpenApiSpecType();
+
+        schema.Type.Should().Be(JsonSchemaType.Boolean);
+        schema.Format.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToOpenApiSpecType_Byte_ReturnsStringWithByteFormat()
+    {
+        var schema = typeof(byte).ToOpenApiSpecType();
+
+        schema.Type.Should().Be(JsonSchemaType.String);
+        schema.Format.Should().Be("byte");
+    }
+
+    [Fact]
+    public void ToOpenApiSpecType_Int_ReturnsIntegerWithInt32Format()
+    {
+        var schema = typeof(int).ToOpenApiSpecType();
+
+        schema.Type.Should().Be(JsonSchemaType.Integer);
+        schema.Format.Should().Be("int32");
+    }
+
+    [Fact]
+    public void ToOpenApiSpecType_UInt_ReturnsIntegerWithInt32Format()
+    {
+        var schema = typeof(uint).ToOpenApiSpecType();
+
+        schema.Type.Should().Be(JsonSchemaType.Integer);
+        schema.Format.Should().Be("int32");
+    }
+
+    [Fact]
+    public void ToOpenApiSpecType_UShort_ReturnsIntegerWithInt32Format()
+    {
+        var schema = typeof(ushort).ToOpenApiSpecType();
+
+        schema.Type.Should().Be(JsonSchemaType.Integer);
+        schema.Format.Should().Be("int32");
+    }
+
+    [Fact]
+    public void ToOpenApiSpecType_Long_ReturnsIntegerWithInt64Format()
+    {
+        var schema = typeof(long).ToOpenApiSpecType();
+
+        schema.Type.Should().Be(JsonSchemaType.Integer);
+        schema.Format.Should().Be("int64");
+    }
+
+    [Fact]
+    public void ToOpenApiSpecType_ULong_ReturnsIntegerWithInt64Format()
+    {
+        var schema = typeof(ulong).ToOpenApiSpecType();
+
+        schema.Type.Should().Be(JsonSchemaType.Integer);
+        schema.Format.Should().Be("int64");
+    }
+
+    [Fact]
+    public void ToOpenApiSpecType_Float_ReturnsNumberWithFloatFormat()
+    {
+        var schema = typeof(float).ToOpenApiSpecType();
+
+        schema.Type.Should().Be(JsonSchemaType.Number);
+        schema.Format.Should().Be("float");
+    }
+
+    [Fact]
+    public void ToOpenApiSpecType_Double_ReturnsNumberWithDoubleFormat()
+    {
+        var schema = typeof(double).ToOpenApiSpecType();
+
+        schema.Type.Should().Be(JsonSchemaType.Number);
+        schema.Format.Should().Be("double");
+    }
+
+    [Fact]
+    public void ToOpenApiSpecType_Decimal_ReturnsNumberWithDoubleFormat()
+    {
+        var schema = typeof(decimal).ToOpenApiSpecType();
+
+        schema.Type.Should().Be(JsonSchemaType.Number);
+        schema.Format.Should().Be("double");
+    }
+
+    [Fact]
+    public void ToOpenApiSpecType_DateTime_ReturnsStringWithDateTimeFormat()
+    {
+        var schema = typeof(DateTime).ToOpenApiSpecType();
+
+        schema.Type.Should().Be(JsonSchemaType.String);
+        schema.Format.Should().Be("date-time");
+    }
+
+    [Fact]
+    public void ToOpenApiSpecType_DateTimeOffset_ReturnsStringWithDateTimeFormat()
+    {
+        var schema = typeof(DateTimeOffset).ToOpenApiSpecType();
+
+        schema.Type.Should().Be(JsonSchemaType.String);
+        schema.Format.Should().Be("date-time");
+    }
+
+    [Fact]
+    public void ToOpenApiSpecType_Guid_ReturnsStringWithUuidFormat()
+    {
+        var schema = typeof(Guid).ToOpenApiSpecType();
+
+        schema.Type.Should().Be(JsonSchemaType.String);
+        schema.Format.Should().Be("uuid");
+    }
+
+    [Fact]
+    public void ToOpenApiSpecType_Char_ReturnsStringType()
+    {
+        var schema = typeof(char).ToOpenApiSpecType();
+
+        schema.Type.Should().Be(JsonSchemaType.String);
+        schema.Format.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToOpenApiSpecType_String_ReturnsStringType()
+    {
+        var schema = typeof(string).ToOpenApiSpecType();
+
+        schema.Type.Should().Be(JsonSchemaType.String);
+        schema.Format.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToOpenApiSpecType_Uri_ReturnsStringType()
+    {
+        var schema = typeof(Uri).ToOpenApiSpecType();
+
+        schema.Type.Should().Be(JsonSchemaType.String);
+        schema.Format.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToOpenApiSpecType_Object_ReturnsObjectType()
+    {
+        var schema = typeof(object).ToOpenApiSpecType();
+
+        schema.Type.Should().Be(JsonSchemaType.Object);
+        schema.Format.Should().BeNull();
+    }
+
+    // Nullable types
+
+    [Fact]
+    public void ToOpenApiSpecType_NullableBool_ReturnsBooleanOrNullType()
+    {
+        var schema = typeof(bool?).ToOpenApiSpecType();
+
+        schema.Type.Should().Be(JsonSchemaType.Boolean | JsonSchemaType.Null);
+        schema.Format.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToOpenApiSpecType_NullableByte_ReturnsStringOrNullWithByteFormat()
+    {
+        var schema = typeof(byte?).ToOpenApiSpecType();
+
+        schema.Type.Should().Be(JsonSchemaType.String | JsonSchemaType.Null);
+        schema.Format.Should().Be("byte");
+    }
+
+    [Fact]
+    public void ToOpenApiSpecType_NullableInt_ReturnsIntegerOrNullWithInt32Format()
+    {
+        var schema = typeof(int?).ToOpenApiSpecType();
+
+        schema.Type.Should().Be(JsonSchemaType.Integer | JsonSchemaType.Null);
+        schema.Format.Should().Be("int32");
+    }
+
+    [Fact]
+    public void ToOpenApiSpecType_NullableUInt_ReturnsIntegerOrNullWithInt32Format()
+    {
+        var schema = typeof(uint?).ToOpenApiSpecType();
+
+        schema.Type.Should().Be(JsonSchemaType.Integer | JsonSchemaType.Null);
+        schema.Format.Should().Be("int32");
+    }
+
+    [Fact]
+    public void ToOpenApiSpecType_NullableUShort_ReturnsIntegerOrNullWithInt32Format()
+    {
+        var schema = typeof(ushort?).ToOpenApiSpecType();
+
+        schema.Type.Should().Be(JsonSchemaType.Integer | JsonSchemaType.Null);
+        schema.Format.Should().Be("int32");
+    }
+
+    [Fact]
+    public void ToOpenApiSpecType_NullableLong_ReturnsIntegerOrNullWithInt64Format()
+    {
+        var schema = typeof(long?).ToOpenApiSpecType();
+
+        schema.Type.Should().Be(JsonSchemaType.Integer | JsonSchemaType.Null);
+        schema.Format.Should().Be("int64");
+    }
+
+    [Fact]
+    public void ToOpenApiSpecType_NullableULong_ReturnsIntegerOrNullWithInt64Format()
+    {
+        var schema = typeof(ulong?).ToOpenApiSpecType();
+
+        schema.Type.Should().Be(JsonSchemaType.Integer | JsonSchemaType.Null);
+        schema.Format.Should().Be("int64");
+    }
+
+    [Fact]
+    public void ToOpenApiSpecType_NullableFloat_ReturnsNumberOrNullWithFloatFormat()
+    {
+        var schema = typeof(float?).ToOpenApiSpecType();
+
+        schema.Type.Should().Be(JsonSchemaType.Number | JsonSchemaType.Null);
+        schema.Format.Should().Be("float");
+    }
+
+    [Fact]
+    public void ToOpenApiSpecType_NullableDouble_ReturnsNumberOrNullWithDoubleFormat()
+    {
+        var schema = typeof(double?).ToOpenApiSpecType();
+
+        schema.Type.Should().Be(JsonSchemaType.Number | JsonSchemaType.Null);
+        schema.Format.Should().Be("double");
+    }
+
+    [Fact]
+    public void ToOpenApiSpecType_NullableDecimal_ReturnsNumberOrNullWithDoubleFormat()
+    {
+        var schema = typeof(decimal?).ToOpenApiSpecType();
+
+        schema.Type.Should().Be(JsonSchemaType.Number | JsonSchemaType.Null);
+        schema.Format.Should().Be("double");
+    }
+
+    [Fact]
+    public void ToOpenApiSpecType_NullableDateTime_ReturnsStringOrNullWithDateTimeFormat()
+    {
+        var schema = typeof(DateTime?).ToOpenApiSpecType();
+
+        schema.Type.Should().Be(JsonSchemaType.String | JsonSchemaType.Null);
+        schema.Format.Should().Be("date-time");
+    }
+
+    [Fact]
+    public void ToOpenApiSpecType_NullableDateTimeOffset_ReturnsStringOrNullWithDateTimeFormat()
+    {
+        var schema = typeof(DateTimeOffset?).ToOpenApiSpecType();
+
+        schema.Type.Should().Be(JsonSchemaType.String | JsonSchemaType.Null);
+        schema.Format.Should().Be("date-time");
+    }
+
+    [Fact]
+    public void ToOpenApiSpecType_NullableGuid_ReturnsStringOrNullWithUuidFormat()
+    {
+        var schema = typeof(Guid?).ToOpenApiSpecType();
+
+        schema.Type.Should().Be(JsonSchemaType.String | JsonSchemaType.Null);
+        schema.Format.Should().Be("uuid");
+    }
+
+    [Fact]
+    public void ToOpenApiSpecType_NullableChar_ReturnsStringOrNullType()
+    {
+        var schema = typeof(char?).ToOpenApiSpecType();
+
+        schema.Type.Should().Be(JsonSchemaType.String | JsonSchemaType.Null);
+        schema.Format.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToOpenApiSpecType_UnknownType_FallsBackToString()
+    {
+        var schema = typeof(TypeMapperTests).ToOpenApiSpecType();
+
+        schema.Type.Should().Be(JsonSchemaType.String);
+        schema.Format.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToOpenApiSpecType_NullType_ThrowsArgumentNullException()
+    {
+        Type nullType = null!;
+
+        var act = () => nullType.ToOpenApiSpecType();
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle.sln
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle.sln
@@ -7,20 +7,54 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AzureFunctions.Extensions.S
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestFunction", "TestFunction\TestFunction.csproj", "{93B84BC0-2017-4BC2-8191-20EDF594E7AC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzureFunctions.Extensions.Swashbuckle.Tests", "AzureFunctions.Extensions.Swashbuckle.Tests\AzureFunctions.Extensions.Swashbuckle.Tests.csproj", "{DC7EBE4F-E12E-4EFF-B8D6-DBC5BA38BAD3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{1E41B7D0-91CC-4232-88E8-ED5330EDB7BF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1E41B7D0-91CC-4232-88E8-ED5330EDB7BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1E41B7D0-91CC-4232-88E8-ED5330EDB7BF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1E41B7D0-91CC-4232-88E8-ED5330EDB7BF}.Debug|x64.Build.0 = Debug|Any CPU
+		{1E41B7D0-91CC-4232-88E8-ED5330EDB7BF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1E41B7D0-91CC-4232-88E8-ED5330EDB7BF}.Debug|x86.Build.0 = Debug|Any CPU
 		{1E41B7D0-91CC-4232-88E8-ED5330EDB7BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1E41B7D0-91CC-4232-88E8-ED5330EDB7BF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1E41B7D0-91CC-4232-88E8-ED5330EDB7BF}.Release|x64.ActiveCfg = Release|Any CPU
+		{1E41B7D0-91CC-4232-88E8-ED5330EDB7BF}.Release|x64.Build.0 = Release|Any CPU
+		{1E41B7D0-91CC-4232-88E8-ED5330EDB7BF}.Release|x86.ActiveCfg = Release|Any CPU
+		{1E41B7D0-91CC-4232-88E8-ED5330EDB7BF}.Release|x86.Build.0 = Release|Any CPU
 		{93B84BC0-2017-4BC2-8191-20EDF594E7AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{93B84BC0-2017-4BC2-8191-20EDF594E7AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{93B84BC0-2017-4BC2-8191-20EDF594E7AC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{93B84BC0-2017-4BC2-8191-20EDF594E7AC}.Debug|x64.Build.0 = Debug|Any CPU
+		{93B84BC0-2017-4BC2-8191-20EDF594E7AC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{93B84BC0-2017-4BC2-8191-20EDF594E7AC}.Debug|x86.Build.0 = Debug|Any CPU
 		{93B84BC0-2017-4BC2-8191-20EDF594E7AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{93B84BC0-2017-4BC2-8191-20EDF594E7AC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{93B84BC0-2017-4BC2-8191-20EDF594E7AC}.Release|x64.ActiveCfg = Release|Any CPU
+		{93B84BC0-2017-4BC2-8191-20EDF594E7AC}.Release|x64.Build.0 = Release|Any CPU
+		{93B84BC0-2017-4BC2-8191-20EDF594E7AC}.Release|x86.ActiveCfg = Release|Any CPU
+		{93B84BC0-2017-4BC2-8191-20EDF594E7AC}.Release|x86.Build.0 = Release|Any CPU
+		{DC7EBE4F-E12E-4EFF-B8D6-DBC5BA38BAD3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DC7EBE4F-E12E-4EFF-B8D6-DBC5BA38BAD3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DC7EBE4F-E12E-4EFF-B8D6-DBC5BA38BAD3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DC7EBE4F-E12E-4EFF-B8D6-DBC5BA38BAD3}.Debug|x64.Build.0 = Debug|Any CPU
+		{DC7EBE4F-E12E-4EFF-B8D6-DBC5BA38BAD3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DC7EBE4F-E12E-4EFF-B8D6-DBC5BA38BAD3}.Debug|x86.Build.0 = Debug|Any CPU
+		{DC7EBE4F-E12E-4EFF-B8D6-DBC5BA38BAD3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DC7EBE4F-E12E-4EFF-B8D6-DBC5BA38BAD3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DC7EBE4F-E12E-4EFF-B8D6-DBC5BA38BAD3}.Release|x64.ActiveCfg = Release|Any CPU
+		{DC7EBE4F-E12E-4EFF-B8D6-DBC5BA38BAD3}.Release|x64.Build.0 = Release|Any CPU
+		{DC7EBE4F-E12E-4EFF-B8D6-DBC5BA38BAD3}.Release|x86.ActiveCfg = Release|Any CPU
+		{DC7EBE4F-E12E-4EFF-B8D6-DBC5BA38BAD3}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/Attribute/QueryStringParameterAttribute.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/Attribute/QueryStringParameterAttribute.cs
@@ -1,5 +1,5 @@
-using Microsoft.OpenApi.Any;
 using System;
+using System.Text.Json.Nodes;
 
 namespace AzureFunctions.Extensions.Swashbuckle.Attribute
 {
@@ -9,55 +9,55 @@ namespace AzureFunctions.Extensions.Swashbuckle.Attribute
         public QueryStringParameterAttribute(string name, string description)
         {
             this.Initialize(name, description);
-            this.Example = new OpenApiNull();
+            this.Example = null;
         }
 
         public QueryStringParameterAttribute(string name, string description, string example)
         {
             this.Initialize(name, description);
             this.DataType = typeof(string);
-            this.Example = new OpenApiString(example);
+            this.Example = JsonValue.Create(example);
         }
 
         public QueryStringParameterAttribute(string name, string description, int example)
         {
             this.Initialize(name, description);
             this.DataType = typeof(int);
-            this.Example = new OpenApiInteger(example);
+            this.Example = JsonValue.Create(example);
         }
 
         public QueryStringParameterAttribute(string name, string description, long example)
         {
             this.Initialize(name, description);
             this.DataType = typeof(long);
-            this.Example = new OpenApiLong(example);
+            this.Example = JsonValue.Create(example);
         }
 
         public QueryStringParameterAttribute(string name, string description, double example)
         {
             this.Initialize(name, description);
-            this.Example = new OpenApiDouble(example);
+            this.Example = JsonValue.Create(example);
         }
 
         public QueryStringParameterAttribute(string name, string description, float example)
         {
             this.Initialize(name, description);
             this.DataType = typeof(float);
-            this.Example = new OpenApiFloat(example);
+            this.Example = JsonValue.Create(example);
         }
 
         public QueryStringParameterAttribute(string name, string description, byte example)
         {
             this.Initialize(name, description);
             this.DataType = typeof(byte);
-            this.Example = new OpenApiByte(example);
+            this.Example = JsonValue.Create(example);
         }
 
         public QueryStringParameterAttribute(string name, string description, bool example)
         {
             this.Initialize(name, description);
             this.DataType = typeof(bool);
-            this.Example = new OpenApiBoolean(example);
+            this.Example = JsonValue.Create(example);
         }
 
         private void Initialize(string name, string description)
@@ -70,7 +70,6 @@ namespace AzureFunctions.Extensions.Swashbuckle.Attribute
         public Type DataType { get; set; }
         public string Description { get; set; }
         public bool Required { get; set; } = false;
-        public IOpenApiAny Example { get; }
+        public JsonNode? Example { get; }
     }
 }
-

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle.csproj
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle.csproj
@@ -1,25 +1,25 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <PackageId>AzureExtensions.Swashbuckle</PackageId>
     <Authors>Vitaly Bibikov</Authors>
-    <Description>Swagger and Swagger UI in Azure Functions by Swashbuckle</Description>
+    <Description>Swagger and Swagger UI for Azure Functions (isolated worker model) powered by Swashbuckle. Supports OpenAPI 2.0, 3.0 and 3.1.</Description>
     <AssemblyName>AzureFunctions.Extensions.Swashbuckle</AssemblyName>
-    <Version>4.0.4</Version>
+    <Version>5.0.0</Version>
     <RootNamespace>AzureFunctions.Extensions.Swashbuckle</RootNamespace>
     <Copyright>vitalybibikov</Copyright>
-    <PackageProjectUrl>https://github.com/vitalybibikov/azure-functions-extensions-swashbuckle</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/vitalybibikov/azure-functions-extensions-swashbuckle</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/vitalybibikov/AzureExtensions.Swashbuckle</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/vitalybibikov/AzureExtensions.Swashbuckle</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>
     <PackageTags>Swagger Swashbuckle Azure Functions openapi openapi3 isolated worker</PackageTags>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Description>Open API</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <EnablePackageValidation>true</EnablePackageValidation>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -40,19 +40,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.3.2">
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.3.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.3">
-    </PackageReference>
-    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.7.3">
-    </PackageReference>
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.7.3">
-    </PackageReference>
-    <PackageReference Include="System.Text.Json" Version="8.0.5">
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="10.1.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="10.1.4" />
+    <PackageReference Include="System.Text.Json" Version="9.0.5">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
@@ -74,7 +71,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.102" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
@@ -89,10 +86,18 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
+    <None Include="..\..\..\README.md">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
   </ItemGroup>
 
   <PropertyGroup>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="AzureFunctions.Extensions.Swashbuckle.Tests" />
+  </ItemGroup>
 
 </Project>

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/ISwashBuckleClient.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/ISwashBuckleClient.cs
@@ -1,12 +1,13 @@
-﻿using System.IO;
+using System.IO;
+using System.Threading.Tasks;
 
 namespace AzureFunctions.Extensions.Swashbuckle
 {
     public interface ISwashBuckleClient
     {
         string RoutePrefix { get; }
-        Stream GetSwaggerJsonDocument(string host, string documentName = "v1");
-        Stream GetSwaggerYamlDocument(string host, string documentName = "v1");
+        Task<Stream> GetSwaggerJsonDocumentAsync(string host, string documentName = "v1");
+        Task<Stream> GetSwaggerYamlDocumentAsync(string host, string documentName = "v1");
         Stream GetSwaggerUi(string swaggerUrl);
         Stream GetSwaggerOAuth2Redirect();
     }

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckle/Filters/FileUploadOperationFilter.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckle/Filters/FileUploadOperationFilter.cs
@@ -1,8 +1,8 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json.Nodes;
 using AzureFunctions.Extensions.Swashbuckle.Attribute;
-using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters
@@ -27,14 +27,21 @@ namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters
                 }
 
                 var uploadFile = swaggerUploadFiles.First();
-                operation.RequestBody ??= new OpenApiRequestBody();
 
-                if (!operation.RequestBody.Content.ContainsKey(MimeType))
+                if (operation.RequestBody is not OpenApiRequestBody requestBodyRef)
                 {
-                    operation.RequestBody.Content[MimeType] = new OpenApiMediaType();
+                    requestBodyRef = new OpenApiRequestBody();
+                    operation.RequestBody = requestBodyRef;
                 }
 
-                operation.RequestBody.Content[MimeType].Schema ??= new OpenApiSchema();
+                requestBodyRef.Content ??= new Dictionary<string, OpenApiMediaType>();
+
+                if (!requestBodyRef.Content.ContainsKey(MimeType))
+                {
+                    requestBodyRef.Content[MimeType] = new OpenApiMediaType();
+                }
+
+                requestBodyRef.Content[MimeType].Schema ??= new OpenApiSchema();
 
                 var uploadFileName = string.IsNullOrEmpty(uploadFile.Name)
                     ? "uploadedFile"
@@ -44,40 +51,34 @@ namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters
                     ? "File to upload."
                     : uploadFile.Description;
 
+                var fileSchema = new OpenApiSchema
+                {
+                    Type = JsonSchemaType.Object,
+                    Required = new HashSet<string> { uploadFileName }
+                };
+
+                fileSchema.Properties ??= new Dictionary<string, IOpenApiSchema>();
+                fileSchema.Properties[uploadFileName] = new OpenApiSchema
+                {
+                    Description = uploadFileDescription,
+                    Type = JsonSchemaType.String,
+                    Format = "binary"
+                };
+
                 var uploadFileMediaType = new OpenApiMediaType
                 {
-                    Schema = new OpenApiSchema
-                    {
-                        Type = "object",
-                        Properties =
-                        {
-                            [uploadFileName] = new OpenApiSchema
-                            {
-                                Description = uploadFileDescription,
-                                Type = "file",
-                                Format = "binary"
-                            }
-                        },
-                        Required = new HashSet<string>
-                        {
-                            uploadFileName
-                        }
-                    }
+                    Schema = fileSchema
                 };
 
-                operation.RequestBody = new OpenApiRequestBody
-                {
-                    Content =
-                    {
-                        [MimeType] = uploadFileMediaType
-                    }
-                };
+                var newRequestBody = new OpenApiRequestBody();
+                newRequestBody.Content ??= new Dictionary<string, OpenApiMediaType>();
+                newRequestBody.Content[MimeType] = uploadFileMediaType;
+                operation.RequestBody = newRequestBody;
 
-                if (!string.IsNullOrEmpty(uploadFile.Example))
+                if (!string.IsNullOrEmpty(uploadFile.Example) && fileSchema is OpenApiSchema concreteSchema)
                 {
-                    operation.RequestBody.Content[MimeType].Schema.Example =
-                        new OpenApiString(uploadFile.Example);
-                    operation.RequestBody.Content[MimeType].Schema.Description = uploadFile.Example;
+                    concreteSchema.Example = JsonValue.Create(uploadFile.Example);
+                    concreteSchema.Description = uploadFile.Example;
                 }
             }
         }

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckle/Filters/FunctionsOperationFilter.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckle/Filters/FunctionsOperationFilter.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using AzureFunctions.Extensions.Swashbuckle.Attribute;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters
@@ -9,10 +9,7 @@ namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters
     {
         public void Apply(OpenApiOperation operation, OperationFilterContext context)
         {
-            operation.Parameters ??= new List<OpenApiParameter>
-            {
-                Capacity = 4
-            };
+            operation.Parameters ??= new List<IOpenApiParameter>();
 
             foreach (var customAttribute in context.MethodInfo.GetCustomAttributes(typeof(RequestHttpHeaderAttribute), false))
             {
@@ -20,7 +17,7 @@ namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters
                 {
                     Name = (customAttribute as RequestHttpHeaderAttribute)!.HeaderName,
                     In = ParameterLocation.Header,
-                    Schema = new OpenApiSchema { Type = "string" },
+                    Schema = new OpenApiSchema { Type = JsonSchemaType.String },
                     Required = (customAttribute as RequestHttpHeaderAttribute)!.IsRequired
                 });
             }
@@ -32,7 +29,7 @@ namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters
                 {
                     Name = (customAttribute as RequestHttpHeaderAttribute)!.HeaderName,
                     In = ParameterLocation.Header,
-                    Schema = new OpenApiSchema { Type = "string" },
+                    Schema = new OpenApiSchema { Type = JsonSchemaType.String },
                     Required = (customAttribute as RequestHttpHeaderAttribute)!.IsRequired
                 });
             }

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckle/Filters/GenerateOperationIdFilter.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckle/Filters/GenerateOperationIdFilter.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc.Controllers;
-using Microsoft.OpenApi.Models;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckle/Filters/Mapper/JsonMapper.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckle/Filters/Mapper/JsonMapper.cs
@@ -1,11 +1,11 @@
 using System.Text.Json;
-using Microsoft.OpenApi.Any;
+using System.Text.Json.Nodes;
 
 namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters.Mapper
 {
     public static class JsonMapper
     {
-        public static IOpenApiAny? CreateFromJson(string str)
+        public static JsonNode? CreateFromJson(string str)
         {
             try
             {
@@ -14,45 +14,45 @@ namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters.Mapper
 
                 if (jsonElement.ValueKind == JsonValueKind.True || jsonElement.ValueKind == JsonValueKind.False)
                 {
-                    return new OpenApiBoolean(jsonElement.GetBoolean());
+                    return JsonValue.Create(jsonElement.GetBoolean());
                 }
 
                 if (jsonElement.ValueKind == JsonValueKind.Number)
                 {
                     if (jsonElement.TryGetInt32(out var intValue))
                     {
-                        return new OpenApiInteger(intValue);
+                        return JsonValue.Create(intValue);
                     }
 
                     if (jsonElement.TryGetInt64(out var longValue))
                     {
-                        return new OpenApiLong(longValue);
+                        return JsonValue.Create(longValue);
                     }
 
                     if (jsonElement.TryGetSingle(out var floatValue) && !float.IsInfinity(floatValue))
                     {
-                        return new OpenApiFloat(floatValue);
+                        return JsonValue.Create(floatValue);
                     }
 
                     if (jsonElement.TryGetDouble(out var doubleValue))
                     {
-                        return new OpenApiDouble(doubleValue);
+                        return JsonValue.Create(doubleValue);
                     }
                 }
 
                 if (jsonElement.ValueKind == JsonValueKind.String)
                 {
-                    return new OpenApiString(jsonElement.ToString());
+                    return JsonValue.Create(jsonElement.ToString());
                 }
 
                 if (jsonElement.ValueKind == JsonValueKind.Null)
                 {
-                    return new OpenApiNull();
+                    return null;
                 }
 
                 if (jsonElement.ValueKind == JsonValueKind.Array)
                 {
-                    return CreateOpenApiArray(jsonElement.EnumerateArray());
+                    return CreateJsonArray(jsonElement.EnumerateArray());
                 }
             }
             catch
@@ -62,9 +62,9 @@ namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters.Mapper
             return null;
         }
 
-        private static IOpenApiAny CreateOpenApiArray(IEnumerable<JsonElement> jsonElements)
+        private static JsonNode CreateJsonArray(IEnumerable<JsonElement> jsonElements)
         {
-            var openApiArray = new OpenApiArray();
+            var jsonArray = new JsonArray();
 
             foreach (var jsonElement in jsonElements)
             {
@@ -72,10 +72,10 @@ namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters.Mapper
                     ? $"\"{jsonElement}\""
                     : jsonElement.ToString();
 
-                openApiArray.Add(CreateFromJson(json));
+                jsonArray.Add(CreateFromJson(json));
             }
 
-            return openApiArray;
+            return jsonArray;
         }
     }
 }

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckle/Filters/Mapper/TypeMapper.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckle/Filters/Mapper/TypeMapper.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 
 namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters.Mapper
 {
@@ -9,43 +9,43 @@ namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters.Mapper
         private static readonly Dictionary<Type, Func<OpenApiSchema>> SimpleTypeToOpenApiSchema =
             new Dictionary<Type, Func<OpenApiSchema>>
             {
-                [typeof(bool)] = () => new OpenApiSchema { Type = "boolean" },
-                [typeof(byte)] = () => new OpenApiSchema { Type = "string", Format = "byte" },
-                [typeof(int)] = () => new OpenApiSchema { Type = "integer", Format = "int32" },
-                [typeof(uint)] = () => new OpenApiSchema { Type = "integer", Format = "int32" },
-                [typeof(ushort)] = () => new OpenApiSchema { Type = "integer", Format = "int32" },
-                [typeof(long)] = () => new OpenApiSchema { Type = "integer", Format = "int64" },
-                [typeof(ulong)] = () => new OpenApiSchema { Type = "integer", Format = "int64" },
-                [typeof(float)] = () => new OpenApiSchema { Type = "number", Format = "float" },
-                [typeof(double)] = () => new OpenApiSchema { Type = "number", Format = "double" },
-                [typeof(decimal)] = () => new OpenApiSchema { Type = "number", Format = "double" },
-                [typeof(DateTime)] = () => new OpenApiSchema { Type = "string", Format = "date-time" },
-                [typeof(DateTimeOffset)] = () => new OpenApiSchema { Type = "string", Format = "date-time" },
-                [typeof(Guid)] = () => new OpenApiSchema { Type = "string", Format = "uuid" },
-                [typeof(char)] = () => new OpenApiSchema { Type = "string" },
+                [typeof(bool)] = () => new OpenApiSchema { Type = JsonSchemaType.Boolean },
+                [typeof(byte)] = () => new OpenApiSchema { Type = JsonSchemaType.String, Format = "byte" },
+                [typeof(int)] = () => new OpenApiSchema { Type = JsonSchemaType.Integer, Format = "int32" },
+                [typeof(uint)] = () => new OpenApiSchema { Type = JsonSchemaType.Integer, Format = "int32" },
+                [typeof(ushort)] = () => new OpenApiSchema { Type = JsonSchemaType.Integer, Format = "int32" },
+                [typeof(long)] = () => new OpenApiSchema { Type = JsonSchemaType.Integer, Format = "int64" },
+                [typeof(ulong)] = () => new OpenApiSchema { Type = JsonSchemaType.Integer, Format = "int64" },
+                [typeof(float)] = () => new OpenApiSchema { Type = JsonSchemaType.Number, Format = "float" },
+                [typeof(double)] = () => new OpenApiSchema { Type = JsonSchemaType.Number, Format = "double" },
+                [typeof(decimal)] = () => new OpenApiSchema { Type = JsonSchemaType.Number, Format = "double" },
+                [typeof(DateTime)] = () => new OpenApiSchema { Type = JsonSchemaType.String, Format = "date-time" },
+                [typeof(DateTimeOffset)] = () => new OpenApiSchema { Type = JsonSchemaType.String, Format = "date-time" },
+                [typeof(Guid)] = () => new OpenApiSchema { Type = JsonSchemaType.String, Format = "uuid" },
+                [typeof(char)] = () => new OpenApiSchema { Type = JsonSchemaType.String },
 
-                [typeof(bool?)] = () => new OpenApiSchema { Type = "boolean", Nullable = true },
-                [typeof(byte?)] = () => new OpenApiSchema { Type = "string", Format = "byte", Nullable = true },
-                [typeof(int?)] = () => new OpenApiSchema { Type = "integer", Format = "int32", Nullable = true },
-                [typeof(uint?)] = () => new OpenApiSchema { Type = "integer", Format = "int32", Nullable = true },
-                [typeof(ushort?)] = () => new OpenApiSchema { Type = "integer", Format = "int32", Nullable = true },
-                [typeof(long?)] = () => new OpenApiSchema { Type = "integer", Format = "int64", Nullable = true },
-                [typeof(ulong?)] = () => new OpenApiSchema { Type = "integer", Format = "int64", Nullable = true },
-                [typeof(float?)] = () => new OpenApiSchema { Type = "number", Format = "float", Nullable = true },
-                [typeof(double?)] = () => new OpenApiSchema { Type = "number", Format = "double", Nullable = true },
-                [typeof(decimal?)] = () => new OpenApiSchema { Type = "number", Format = "double", Nullable = true },
-                [typeof(DateTime?)] = () => new OpenApiSchema { Type = "string", Format = "date-time", Nullable = true },
+                [typeof(bool?)] = () => new OpenApiSchema { Type = JsonSchemaType.Boolean | JsonSchemaType.Null },
+                [typeof(byte?)] = () => new OpenApiSchema { Type = JsonSchemaType.String | JsonSchemaType.Null, Format = "byte" },
+                [typeof(int?)] = () => new OpenApiSchema { Type = JsonSchemaType.Integer | JsonSchemaType.Null, Format = "int32" },
+                [typeof(uint?)] = () => new OpenApiSchema { Type = JsonSchemaType.Integer | JsonSchemaType.Null, Format = "int32" },
+                [typeof(ushort?)] = () => new OpenApiSchema { Type = JsonSchemaType.Integer | JsonSchemaType.Null, Format = "int32" },
+                [typeof(long?)] = () => new OpenApiSchema { Type = JsonSchemaType.Integer | JsonSchemaType.Null, Format = "int64" },
+                [typeof(ulong?)] = () => new OpenApiSchema { Type = JsonSchemaType.Integer | JsonSchemaType.Null, Format = "int64" },
+                [typeof(float?)] = () => new OpenApiSchema { Type = JsonSchemaType.Number | JsonSchemaType.Null, Format = "float" },
+                [typeof(double?)] = () => new OpenApiSchema { Type = JsonSchemaType.Number | JsonSchemaType.Null, Format = "double" },
+                [typeof(decimal?)] = () => new OpenApiSchema { Type = JsonSchemaType.Number | JsonSchemaType.Null, Format = "double" },
+                [typeof(DateTime?)] = () => new OpenApiSchema { Type = JsonSchemaType.String | JsonSchemaType.Null, Format = "date-time" },
                 [typeof(DateTimeOffset?)] = () =>
-                    new OpenApiSchema { Type = "string", Format = "date-time", Nullable = true },
-                [typeof(Guid?)] = () => new OpenApiSchema { Type = "string", Format = "uuid", Nullable = true },
-                [typeof(char?)] = () => new OpenApiSchema { Type = "string", Nullable = true },
+                    new OpenApiSchema { Type = JsonSchemaType.String | JsonSchemaType.Null, Format = "date-time" },
+                [typeof(Guid?)] = () => new OpenApiSchema { Type = JsonSchemaType.String | JsonSchemaType.Null, Format = "uuid" },
+                [typeof(char?)] = () => new OpenApiSchema { Type = JsonSchemaType.String | JsonSchemaType.Null },
 
                 // Uri is treated as simple string.
-                [typeof(Uri)] = () => new OpenApiSchema { Type = "string" },
+                [typeof(Uri)] = () => new OpenApiSchema { Type = JsonSchemaType.String },
 
-                [typeof(string)] = () => new OpenApiSchema { Type = "string" },
+                [typeof(string)] = () => new OpenApiSchema { Type = JsonSchemaType.String },
 
-                [typeof(object)] = () => new OpenApiSchema { Type = "object" }
+                [typeof(object)] = () => new OpenApiSchema { Type = JsonSchemaType.Object }
             };
 
         public static OpenApiSchema ToOpenApiSpecType(this Type type)
@@ -57,7 +57,7 @@ namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters.Mapper
 
             return SimpleTypeToOpenApiSchema.TryGetValue(type, out var result)
                 ? result()
-                : new OpenApiSchema { Type = "string" };
+                : new OpenApiSchema { Type = JsonSchemaType.String };
         }
     }
 }

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckle/Filters/QueryStringParameterAttributeFilter.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckle/Filters/QueryStringParameterAttributeFilter.cs
@@ -1,7 +1,6 @@
 using System.Linq;
 using AzureFunctions.Extensions.Swashbuckle.Attribute;
-using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters
@@ -34,23 +33,17 @@ namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters
                         Schema = this.schemaGenerator.GenerateSchema(attribute?.DataType, new SchemaRepository())
                     };
 
-                    if (attribute != null)
+                    if (attribute != null && attribute.Example != null)
                     {
-                        switch (attribute.Example)
+                        if (apiParameter.Schema is OpenApiSchema concreteSchema)
                         {
-                            case OpenApiNull _:
-                                /* ignore */
-                                break;
-
-                            default:
-                                // set both examples
-                                apiParameter.Schema.Example = attribute.Example;
-                                apiParameter.Example = apiParameter.Schema.Example;
-                                break;
+                            concreteSchema.Example = attribute.Example;
                         }
+
+                        apiParameter.Example = attribute.Example;
                     }
 
-                    operation.Parameters.Add(apiParameter);
+                    operation.Parameters?.Add(apiParameter);
                 }
             }
         }

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckle/Filters/XmlCommentsOperationFilterWithParams.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckle/Filters/XmlCommentsOperationFilterWithParams.cs
@@ -1,6 +1,6 @@
 using System.Reflection;
 using System.Xml.XPath;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters
@@ -38,7 +38,7 @@ namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters
         private void ApplyParameters(OpenApiOperation operation, MethodInfo methodInfo)
         {
             if (methodInfo != null)
-            {   
+            {
                 var methodMemberName = XmlCommentsNodeNameHelper.GetMemberNameForMethod(methodInfo);
                 foreach (var parameter in methodInfo.GetParameters())
                 {
@@ -51,7 +51,7 @@ namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters
                         {
                             var humanizedDescription = XmlCommentsTextHelper.Humanize(paramNode.InnerXml);
 
-                            var operationParameter = operation.Parameters
+                            var operationParameter = operation.Parameters?
                                 .FirstOrDefault(x => x.Name == parameter.Name);
 
                             if (operationParameter != null)
@@ -92,7 +92,7 @@ namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters
             {
                 operation.Description = XmlCommentsTextHelper.Humanize(remarksNode.InnerXml);
             }
-            
+
             var responseNodes = methodNode.Select("response");
             this.ApplyResponseTags(operation, responseNodes);
         }
@@ -102,6 +102,7 @@ namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters
             while (responseNodes.MoveNext())
             {
                 var code = responseNodes.Current!.GetAttribute("code", string.Empty);
+                operation.Responses ??= new OpenApiResponses();
                 var response = operation.Responses.TryGetValue(code, out var operationResponse)
                     ? operationResponse
                     : operation.Responses[code] = new OpenApiResponse();

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckle/Filters/XmlCommentsParameterFilterWithExamples.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckle/Filters/XmlCommentsParameterFilterWithExamples.cs
@@ -2,7 +2,7 @@ using System;
 using System.Reflection;
 using System.Xml.XPath;
 using AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters.Mapper;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters
@@ -16,7 +16,7 @@ namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters
             this.xmlNavigator = xmlDoc.CreateNavigator() ?? throw new ArgumentException();
         }
 
-        public void Apply(OpenApiParameter parameter, ParameterFilterContext context)
+        public void Apply(IOpenApiParameter parameter, ParameterFilterContext context)
         {
             if (context.PropertyInfo != null)
             {
@@ -28,7 +28,7 @@ namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters
             }
         }
 
-        private void ApplyPropertyTags(OpenApiParameter parameter, PropertyInfo propertyInfo)
+        private void ApplyPropertyTags(IOpenApiParameter parameter, PropertyInfo propertyInfo)
         {
             var propertyMemberName = XmlCommentsNodeNameHelper.GetMemberNameForFieldOrProperty(propertyInfo);
             var propertyNode = this.xmlNavigator.SelectSingleNode($"/doc/members/member[@name='{propertyMemberName}']");
@@ -43,15 +43,15 @@ namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters
             {
                 parameter.Description = XmlCommentsTextHelper.Humanize(summaryNode.InnerXml);
             }
-            
+
             var exampleNode = propertyNode.SelectSingleNode("example");
-            if (exampleNode != null)
+            if (exampleNode != null && parameter is OpenApiParameter concreteParameter)
             {
-                parameter.Example = JsonMapper.CreateFromJson(exampleNode.InnerXml);
+                concreteParameter.Example = JsonMapper.CreateFromJson(exampleNode.InnerXml);
             }
         }
 
-        private void ApplyParamTags(OpenApiParameter parameter, ParameterInfo parameterInfo)
+        private void ApplyParamTags(IOpenApiParameter parameter, ParameterInfo parameterInfo)
         {
             if (!(parameterInfo.Member is MethodInfo methodInfo))
             {
@@ -77,9 +77,9 @@ namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters
                 parameter.Description = XmlCommentsTextHelper.Humanize(paramNode.InnerXml);
 
                 var example = paramNode.GetAttribute("example", string.Empty);
-                if (!string.IsNullOrEmpty(example))
+                if (!string.IsNullOrEmpty(example) && parameter is OpenApiParameter concreteParameter)
                 {
-                    parameter.Example = JsonMapper.CreateFromJson(example);
+                    concreteParameter.Example = JsonMapper.CreateFromJson(example);
                 }
             }
         }

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckle/Filters/XmlCommentsSchemaFilterChanged.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckle/Filters/XmlCommentsSchemaFilterChanged.cs
@@ -2,7 +2,7 @@ using System;
 using System.Reflection;
 using System.Xml.XPath;
 using AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters.Mapper;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters
@@ -16,7 +16,7 @@ namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters
             this.xmlNavigator = xmlDoc.CreateNavigator() ?? throw new ArgumentException();
         }
 
-        public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+        public void Apply(IOpenApiSchema schema, SchemaFilterContext context)
         {
             this.ApplyTypeTags(schema, context.Type);
 
@@ -26,7 +26,7 @@ namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters
             }
         }
 
-        private void ApplyTypeTags(OpenApiSchema schema, Type type)
+        private void ApplyTypeTags(IOpenApiSchema schema, Type type)
         {
             var typeMemberName = XmlCommentsNodeNameHelper.GetMemberNameForType(type);
             var typeSummaryNode = this.xmlNavigator.SelectSingleNode($"/doc/members/member[@name='{typeMemberName}']/summary");
@@ -37,7 +37,7 @@ namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters
             }
         }
 
-        private void ApplyFieldOrPropertyTags(OpenApiSchema schema, MemberInfo fieldOrPropertyInfo)
+        private void ApplyFieldOrPropertyTags(IOpenApiSchema schema, MemberInfo fieldOrPropertyInfo)
         {
             var fieldOrPropertyMemberName = XmlCommentsNodeNameHelper.GetMemberNameForFieldOrProperty(fieldOrPropertyInfo);
             var fieldOrPropertyNode = this.xmlNavigator.SelectSingleNode($"/doc/members/member[@name='{fieldOrPropertyMemberName}']");
@@ -54,9 +54,9 @@ namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Filters
             }
 
             var exampleNode = fieldOrPropertyNode.SelectSingleNode("example");
-            if (exampleNode != null)
+            if (exampleNode != null && schema is OpenApiSchema concreteSchema)
             {
-                schema.Example = JsonMapper.CreateFromJson(exampleNode.InnerXml);
+                concreteSchema.Example = JsonMapper.CreateFromJson(exampleNode.InnerXml);
             }
         }
     }

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckle/Providers/FunctionApiDescriptionProvider.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckle/Providers/FunctionApiDescriptionProvider.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -317,7 +318,8 @@ namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Providers
                     parameter.GetCustomAttribute(typeof(RequestBodyTypeAttribute)) as RequestBodyTypeAttribute;
 
                 if ((parameter.ParameterType == typeof(HttpRequestMessage) ||
-                     parameter.ParameterType == typeof(HttpRequest))
+                     parameter.ParameterType == typeof(HttpRequest) ||
+                     parameter.ParameterType == typeof(HttpRequestData))
                     && requestBodyTypeAttribute == null)
                 {
                     continue;
@@ -378,6 +380,11 @@ namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle.Providers
             }
 
             if (parameter.ParameterType == typeof(ExecutionContext))
+            {
+                return true;
+            }
+
+            if (parameter.ParameterType == typeof(FunctionContext))
             {
                 return true;
             }

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckle/SwashBuckleClient.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckle/SwashBuckleClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle
 {
@@ -12,14 +13,14 @@ namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle
             _config = config;
         }
 
-        public Stream GetSwaggerJsonDocument(string host, string documentName = "v1")
+        public async Task<Stream> GetSwaggerJsonDocumentAsync(string host, string documentName = "v1")
         {
-            return _config.GetSwaggerJsonDocument(host, documentName);
+            return await _config.GetSwaggerJsonDocumentAsync(host, documentName);
         }
 
-        public Stream GetSwaggerYamlDocument(string host, string documentName = "v1")
+        public async Task<Stream> GetSwaggerYamlDocumentAsync(string host, string documentName = "v1")
         {
-            return _config.GetSwaggerYamlDocument(host, documentName);
+            return await _config.GetSwaggerYamlDocumentAsync(host, documentName);
         }
 
         public Stream GetSwaggerOAuth2Redirect()

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckle/SwashbuckleConfig.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckle/SwashbuckleConfig.cs
@@ -10,8 +10,6 @@ using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.OpenApi;
-using Microsoft.OpenApi.Extensions;
-using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.Swagger;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
@@ -74,16 +72,21 @@ namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle
                     throw new ArgumentNullException(nameof(binPath), "Not found path to an xml directory");
                 }
 
-                var binDirectory = Directory.CreateDirectory(binPath);
-                var xmlBasePath = binDirectory?.Parent?.FullName;
-
-                if (xmlBasePath != null)
+                // Search for XML file in multiple locations:
+                // 1. Same directory as the assembly (e.g., bin/Debug/net8.0/)
+                // 2. Parent directory (e.g., bin/Debug/) for backward compatibility
+                var candidatePaths = new[]
                 {
-                    var path = Path.Combine(xmlBasePath, this.swaggerOptions.XmlPath);
+                    Path.Combine(binPath, this.swaggerOptions.XmlPath),
+                    Path.Combine(Directory.CreateDirectory(binPath).Parent?.FullName ?? binPath, this.swaggerOptions.XmlPath)
+                };
 
-                    if (File.Exists(path))
+                foreach (var candidatePath in candidatePaths)
+                {
+                    if (File.Exists(candidatePath))
                     {
-                        this.xmlPath = path;
+                        this.xmlPath = candidatePath;
+                        break;
                     }
                 }
             }
@@ -177,18 +180,18 @@ namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle
                 .Replace("{usePkceWithAuthorizationCodeGrant}", this.swaggerOptions.UsePkceWithAuthorizationCodeGrant ? "true" : "false");
         }
 
-        public Stream GetSwaggerJsonDocument(string host, string documentName = "v1")
+        public async Task<Stream> GetSwaggerJsonDocumentAsync(string host, string documentName = "v1")
         {
             var swaggerProvider = this.serviceProvider!.GetRequiredService<ISwaggerProvider>();
             var document = swaggerProvider.GetSwagger(documentName, host, string.Empty);
-            return this.SerializeJsonDocument(document);
+            return await this.SerializeJsonDocumentAsync(document);
         }
 
-        public Stream GetSwaggerYamlDocument(string host, string documentName = "v1")
+        public async Task<Stream> GetSwaggerYamlDocumentAsync(string host, string documentName = "v1")
         {
             var swaggerProvider = this.serviceProvider!.GetRequiredService<ISwaggerProvider>();
             var document = swaggerProvider.GetSwagger(documentName, host, string.Empty);
-            return this.SerializeYamlDocument(document);
+            return await this.SerializeYamlDocumentAsync(document);
         }
 
         private static void AddSwaggerDocument(SwaggerGenOptions options, SwaggerDocument document)
@@ -200,6 +203,7 @@ namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle
                 Description = document.Description
             });
         }
+
         private static Assembly GetAssembly()
         {
             var assembly = Assembly.GetAssembly(typeof(SwashBuckleClient));
@@ -230,23 +234,31 @@ namespace AzureFunctions.Extensions.Swashbuckle.SwashBuckle
             return documentHtml;
         }
 
-        private MemoryStream SerializeJsonDocument(OpenApiDocument document)
+        private async Task<MemoryStream> SerializeJsonDocumentAsync(OpenApiDocument document)
         {
             var memoryStream = new MemoryStream();
-            document.SerializeAsJson(
-                memoryStream,
-                this.swaggerOptions.SpecVersion == OpenApiSpecVersion.OpenApi2_0 ? OpenApiSpecVersion.OpenApi2_0 : OpenApiSpecVersion.OpenApi3_0);
+            var specVersion = this.swaggerOptions.SpecVersion == OpenApiSpecVersion.OpenApi2_0
+                ? OpenApiSpecVersion.OpenApi2_0
+                : OpenApiSpecVersion.OpenApi3_0;
+
+            var writer = new OpenApiJsonWriter(new StreamWriter(memoryStream));
+            await document.SerializeAsync(writer, specVersion);
+            await writer.FlushAsync();
 
             memoryStream.Position = 0;
             return memoryStream;
         }
 
-        private MemoryStream SerializeYamlDocument(OpenApiDocument document)
+        private async Task<MemoryStream> SerializeYamlDocumentAsync(OpenApiDocument document)
         {
             var memoryStream = new MemoryStream();
-            document.SerializeAsYaml(
-                memoryStream,
-                this.swaggerOptions.SpecVersion == OpenApiSpecVersion.OpenApi2_0 ? OpenApiSpecVersion.OpenApi2_0 : OpenApiSpecVersion.OpenApi3_0);
+            var specVersion = this.swaggerOptions.SpecVersion == OpenApiSpecVersion.OpenApi2_0
+                ? OpenApiSpecVersion.OpenApi2_0
+                : OpenApiSpecVersion.OpenApi3_0;
+
+            var writer = new OpenApiYamlWriter(new StreamWriter(memoryStream));
+            await document.SerializeAsync(writer, specVersion);
+            await writer.FlushAsync();
 
             memoryStream.Position = 0;
             return memoryStream;

--- a/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckleClientExtension.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/AzureFunctions.Extensions.Swashbuckle/SwashBuckleClientExtension.cs
@@ -17,14 +17,14 @@ namespace AzureFunctions.Extensions.Swashbuckle
         {
             var host = GetBaseUri(requestData);
 
-            var stream = client.GetSwaggerJsonDocument(host, documentName);
+            var stream = await client.GetSwaggerJsonDocumentAsync(host, documentName);
             var reader = new StreamReader(stream);
             var document = await reader.ReadToEndAsync();
 
             var response = requestData.CreateResponse(HttpStatusCode.OK);
+            response.Headers.Add("Content-Type", "application/json; charset=utf-8");
             await response.WriteStringAsync(document, CancellationToken.None, Encoding.UTF8);
 
-            //response.Headers.Add("Content-Type", "application/json; charset=utf-8");
             return response;
         }
 
@@ -35,14 +35,14 @@ namespace AzureFunctions.Extensions.Swashbuckle
         {
             var host = GetBaseUri(requestData);
 
-            var stream = client.GetSwaggerYamlDocument(host, documentName);
+            var stream = await client.GetSwaggerYamlDocumentAsync(host, documentName);
             var reader = new StreamReader(stream);
 
             var response = requestData.CreateResponse(HttpStatusCode.OK);
+            response.Headers.Add("Content-Type", "application/x-yaml; charset=utf-8");
 
             var document = await reader.ReadToEndAsync();
             await response.WriteStringAsync(document, CancellationToken.None, Encoding.UTF8);
-            response.Headers.Add("Content-Type", "application/json; charset=utf-8");
 
             return response;
         }
@@ -60,10 +60,10 @@ namespace AzureFunctions.Extensions.Swashbuckle
             var stream = client.GetSwaggerUi($"{host}{routePrefix}/{documentRoute}");
 
             var response = requestData.CreateResponse(HttpStatusCode.OK);
+            response.Headers.Add("Content-Type", "text/html; charset=utf-8");
             using var reader = new StreamReader(stream);
             var document = await reader.ReadToEndAsync();
             await response.WriteStringAsync(document, CancellationToken.None, Encoding.UTF8);
-            //response.Headers.Add("Content-Type", "text/html; charset=utf-8");
             return response;
         }
 
@@ -74,17 +74,17 @@ namespace AzureFunctions.Extensions.Swashbuckle
             var stream = client.GetSwaggerOAuth2Redirect();
 
             var response = requestData.CreateResponse(HttpStatusCode.OK);
+            response.Headers.Add("Content-Type", "text/html; charset=utf-8");
             using var reader = new StreamReader(stream);
             var document = await reader.ReadToEndAsync();
             await response.WriteStringAsync(document, CancellationToken.None, Encoding.UTF8);
-            //response.Headers.Add("Content-Type", "text/html; charset=utf-8");
             return response;
         }
 
         private static string GetBaseUri(HttpRequestData requestData)
         {
             var host = requestData.Url.Host;
-            var port = requestData.Url.Port;  // Get the port
+            var port = requestData.Url.Port;
             var scheme = requestData.Url.Scheme;
 
             var hostWithPort = (port == 80 && scheme == "http") || (port == 443 && scheme == "https") ? host : $"{host}:{port}";

--- a/src/AzureFunctions.Extensions.Swashbuckle/TestFunction/CustomFilterExample/RemoveSchemasFilter.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/TestFunction/CustomFilterExample/RemoveSchemasFilter.cs
@@ -1,6 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace TestFunction.CustomFilterExample
@@ -9,9 +9,10 @@ namespace TestFunction.CustomFilterExample
     {
         public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
         {
-            foreach (var item in swaggerDoc.Components.Schemas)
+            var keysToRemove = new List<string>(swaggerDoc.Components.Schemas.Keys);
+            foreach (var key in keysToRemove)
             {
-                swaggerDoc.Components.Schemas.Remove(item.Key);
+                swaggerDoc.Components.Schemas.Remove(key);
             }
         }
     }

--- a/src/AzureFunctions.Extensions.Swashbuckle/TestFunction/Program.cs
+++ b/src/AzureFunctions.Extensions.Swashbuckle/TestFunction/Program.cs
@@ -5,7 +5,6 @@ using System.Reflection;
 using AzureFunctions.Extensions.Swashbuckle.Settings;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi;
-using Microsoft.OpenApi.Models;
 using AzureFunctions.Extensions.Swashbuckle;
 using Swashbuckle.AspNetCore.SwaggerGen;
 

--- a/src/AzureFunctions.Extensions.Swashbuckle/TestFunction/TestFunction.csproj
+++ b/src/AzureFunctions.Extensions.Swashbuckle/TestFunction/TestFunction.csproj
@@ -4,17 +4,17 @@
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile>TestFunction.xml</DocumentationFile>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.23.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.3.2" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.4" />
-    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
+    <PackageReference Include="System.Text.Json" Version="9.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AzureFunctions.Extensions.Swashbuckle/TestFunction/TestFunction.xml
+++ b/src/AzureFunctions.Extensions.Swashbuckle/TestFunction/TestFunction.xml
@@ -81,7 +81,7 @@
         </member>
         <member name="T:TestFunction.GeneratedFunctionMetadataProvider">
             <summary>
-            Custom <see cref="T:Microsoft.Azure.Functions.Worker.Core.FunctionMetadata.IFunctionMetadataProvider"/> implementation that returns function metadata definitions for the current worker."/>
+            Custom <see cref="T:Microsoft.Azure.Functions.Worker.Core.FunctionMetadata.IFunctionMetadataProvider"/> implementation that returns function metadata definitions for the current worker.
             </summary>
         </member>
         <member name="M:TestFunction.GeneratedFunctionMetadataProvider.GetFunctionMetadataAsync(System.String)">


### PR DESCRIPTION
## Summary

Major version bump to **v5.0.0** — comprehensive modernization of the library:

### Core Upgrade
- **Swashbuckle.AspNetCore** 6.7.3 → **10.1.4** (Microsoft.OpenApi v1 → v2)
- **Azure Functions Worker SDK** 1.x → **2.x**
- **Multi-target**: .NET 8.0 (LTS) + .NET 9.0 (STS)
- All `IOpenApiAny` types migrated to `System.Text.Json.Nodes.JsonNode`
- Schema `Type` migrated from `string` to `JsonSchemaType` flagged enum
- Document serialization is now **async** (`GetSwaggerJsonDocumentAsync` / `GetSwaggerYamlDocumentAsync`)

### Bug Fixes
- **#119** — Content-Type header now set correctly before writing response body
- **#122** — `FunctionContext` and `HttpRequestData` no longer treated as body parameters
- **#114** — XML documentation files now found in TFM subdirectories (e.g., `bin/Debug/net8.0/`)

### Infrastructure
- **CI workflow** — Build + test matrix on .NET 8 & 9, NuGet pack + validation
- **Auto-release workflow** — Version detection → GitHub Release → NuGet.org + GitHub Packages
- **76 unit tests** — JsonMapper, TypeMapper, QueryStringParameterAttribute, FileUploadOperationFilter, FunctionsOperationFilter, StartupExtension
- **SourceLink** + deterministic builds + symbol packages (`.snupkg`)
- Redesigned **README** with badges, migration guide, and updated examples

### Breaking Changes
| Change | v4.x | v5.x |
|--------|------|------|
| Swagger document methods | Synchronous | **Async** |
| OpenAPI schema types | `Type = "string"` | `Type = JsonSchemaType.String` |
| Nullable schemas | `Nullable = true` | `JsonSchemaType.X \| JsonSchemaType.Null` |
| OpenAPI namespace | `Microsoft.OpenApi.Models` | `Microsoft.OpenApi` |

### Note on #117
In-process model compatibility is out of scope — in-process Azure Functions reach EOL Nov 2026, and Swashbuckle 10.x requires ASP.NET Core 8+ which is isolated-only.

## Test plan
- [x] Build succeeds on net8.0 and net9.0 (Release mode)
- [x] 76 unit tests pass
- [x] NuGet package packs successfully (`.nupkg` + `.snupkg`)
- [ ] CI workflow runs on GitHub Actions
- [ ] Verify Swagger UI renders correctly in a test Azure Function
- [ ] Verify auto-release triggers on merge (requires `NUGET_PUSH_KEY` secret)

Closes #119, closes #122, closes #114